### PR TITLE
Add option to enable auto plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ terragrunt-atlantis-config generate
 
 # or from anywhere
 terragrunt-atlantis-config generate --root /some/path/to/your/repo/root
+
+# output to a file
+terragrunt-atlantis-config generate --autoplan --output ./output.tf
+
+# enable auto plan
+terragrunt-atlantis-config generate --autoplan
 ```
 
 Finally, check the log output for the YAML.

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -154,7 +154,7 @@ func createProject(sourcePath string) (*AtlantisProject, error) {
 		Dir: relativeSourceDir,
 
 		Autoplan: AutoplanConfig{
-			Enabled:      false,
+			Enabled:      autoPlan,
 			WhenModified: relativeDependencies,
 		},
 	}
@@ -213,6 +213,7 @@ func main(cmd *cobra.Command, args []string) {
 }
 
 var gitRoot string
+var autoPlan bool
 var outputPath string
 
 // generateCmd represents the generate command
@@ -226,6 +227,7 @@ var generateCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(generateCmd)
 
+	generateCmd.PersistentFlags().BoolVar(&autoPlan, "autoplan", false, "Enable auto plan. Default is disabled")
 	generateCmd.PersistentFlags().StringVar(&outputPath, "output", ".", "Path of the file where configuration will be generated. Default is not to write to file")
 	generateCmd.PersistentFlags().StringVar(&gitRoot, "root", ".", "Path to the root directory of the github repo you want to build config for. Default is current dir")
 }


### PR DESCRIPTION
Tested with and without the option `autoplan`
```
terragrunt-atlantis-config generate --autoplan --output ./output.tf
terragrunt-atlantis-config generate --output ./output.tf
```