### PR TITLE
Feature to ignore unplannable terragrunt.hcl files

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ terragrunt-atlantis-config generate
 terragrunt-atlantis-config generate --root /some/path/to/your/repo/root
 
 # output to a file
-terragrunt-atlantis-config generate --autoplan --output ./output.tf
+terragrunt-atlantis-config generate --autoplan --output ./atlantis.yaml
 
 # enable auto plan
 terragrunt-atlantis-config generate --autoplan
 
 # define the workflow
-terragrunt-atlantis-config generate --workflow web --output ./output.tf
+terragrunt-atlantis-config generate --workflow web --output ./atlantis.yaml
 ```
 
 Finally, check the log output for the YAML.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ terragrunt-atlantis-config generate --autoplan
 # define the workflow
 terragrunt-atlantis-config generate --workflow web --output ./atlantis.yaml
 
-# ignore terragrunt configs which do not reference a terraform module, thus, can't be planned
-terragrunt-atlantis-config generate --ignore-unplannable
+# ignore parent terragrunt configs (those which don't reference a terraform module)
+terragrunt-atlantis-config generate --ignore-parent-terragrunt
 ```
 
 Finally, check the log output for the YAML.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ terragrunt-atlantis-config generate --autoplan
 
 # define the workflow
 terragrunt-atlantis-config generate --workflow web --output ./atlantis.yaml
+
+# ignore terragrunt configs which do not reference a terraform module, thus, can't be planned
+terragrunt-atlantis-config generate --ignore-unplannable
 ```
 
 Finally, check the log output for the YAML.

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -109,9 +109,9 @@ func getDependencies(path string) ([]string, error) {
 		return nil, err
 	}
 
-	// if theres no terraform source and we're ignoring unplannable terragrunt configs
+	// if theres no terraform source and we're ignoring parent terragrunt configs
 	// return nils to indicate we should skip this project
-	if (parsedConfig.Terraform == nil || parsedConfig.Terraform.Source == nil) && ignoreUnplannable == true {
+	if (parsedConfig.Terraform == nil || parsedConfig.Terraform.Source == nil) && ignoreParentTerragrunt == true {
 		return nil, nil
 	}
 
@@ -232,7 +232,7 @@ func main(cmd *cobra.Command, args []string) {
 
 var gitRoot string
 var autoPlan bool
-var ignoreUnplannable bool
+var ignoreParentTerragrunt bool
 var workflow string
 var outputPath string
 
@@ -248,7 +248,7 @@ func init() {
 	rootCmd.AddCommand(generateCmd)
 
 	generateCmd.PersistentFlags().BoolVar(&autoPlan, "autoplan", false, "Enable auto plan. Default is disabled")
-	generateCmd.PersistentFlags().BoolVar(&ignoreUnplannable, "ignore-unplannable", false, "Ignore terragrunt configs which do not reference a terraform module, thus, can't be planned. Default is disabled")
+	generateCmd.PersistentFlags().BoolVar(&ignoreParentTerragrunt, "ignore-parent-terragrunt", false, "Ignore parent terragrunt configs (those which don't reference a terraform module). Default is disabled")
 	generateCmd.PersistentFlags().StringVar(&workflow, "workflow", ".", "Name of the workflow to be customized in the atlantis server. Default is to not set")
 	generateCmd.PersistentFlags().StringVar(&outputPath, "output", ".", "Path of the file where configuration will be generated. Default is not to write to file")
 	generateCmd.PersistentFlags().StringVar(&gitRoot, "root", ".", "Path to the root directory of the github repo you want to build config for. Default is current dir")

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -109,6 +109,12 @@ func getDependencies(path string) ([]string, error) {
 		return nil, err
 	}
 
+	// if theres no terraform source and we're ignoring unplannable terragrunt configs
+	// return nils to indicate we should skip this project
+	if (parsedConfig.Terraform == nil || parsedConfig.Terraform.Source == nil) && ignoreUnplannable == true {
+		return nil, nil
+	}
+
 	dependencies := []string{}
 
 	if parsedConfig.Dependencies != nil {
@@ -131,6 +137,10 @@ func createProject(sourcePath string) (*AtlantisProject, error) {
 	dependencies, err := getDependencies(sourcePath)
 	if err != nil {
 		return nil, err
+	}
+	// if dependecies AND err is nil then return nils to indicate we should skip this project
+	if err == nil && dependencies == nil {
+		return nil, nil
 	}
 
 	absoluteSourceDir := filepath.Dir(sourcePath)
@@ -201,6 +211,11 @@ func main(cmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal("Could not create project for ", terragruntPath, " with err: ", err)
 		}
+		// if project and err are nil then skip this project
+		if err == nil && project == nil {
+			continue
+		}
+
 		log.Info("Created project for ", terragruntPath)
 		config.Projects = append(config.Projects, *project)
 	}
@@ -217,6 +232,7 @@ func main(cmd *cobra.Command, args []string) {
 
 var gitRoot string
 var autoPlan bool
+var ignoreUnplannable bool
 var workflow string
 var outputPath string
 
@@ -232,6 +248,7 @@ func init() {
 	rootCmd.AddCommand(generateCmd)
 
 	generateCmd.PersistentFlags().BoolVar(&autoPlan, "autoplan", false, "Enable auto plan. Default is disabled")
+	generateCmd.PersistentFlags().BoolVar(&ignoreUnplannable, "ignore-unplannable", false, "Ignore terragrunt configs which do not reference a terraform module, thus, can't be planned. Default is disabled")
 	generateCmd.PersistentFlags().StringVar(&workflow, "workflow", ".", "Name of the workflow to be customized in the atlantis server. Default is to not set")
 	generateCmd.PersistentFlags().StringVar(&outputPath, "output", ".", "Path of the file where configuration will be generated. Default is not to write to file")
 	generateCmd.PersistentFlags().StringVar(&gitRoot, "root", ".", "Path to the root directory of the github repo you want to build config for. Default is current dir")


### PR DESCRIPTION
# use case
Most commonly this will help out with repos that have a root-level parent `terragrunt.hcl` which doesn't actually provision anything itself.  In these cases we don't want to create a project in the `atlantis.yaml` because the plan will always be blank or error out.

# implementation
We detect when a terragrunt.hcl file has an empty `terraform` block or an empty `terraform.source` parameter.  Also there's a command-line option to enable (default disabled)