### PR TITLE
Add `/terragrunt.hcl` to the end of all dependency paths

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -148,7 +148,8 @@ func createProject(sourcePath string) (*AtlantisProject, error) {
 		if err != nil {
 			return nil, err
 		}
-		relativeDependencies = append(relativeDependencies, filepath.ToSlash(relativePath))
+		dependency := filepath.ToSlash(filepath.Join(relativePath, "terragrunt.hcl"))
+		relativeDependencies = append(relativeDependencies, dependency)
 	}
 
 	relativeSourceDir := strings.TrimPrefix(absoluteSourceDir, gitRoot)

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -44,7 +44,7 @@ func runTest(t *testing.T, goldenFile string, args []string) {
 	}
 
 	if string(content) != string(goldenContents) {
-		t.Errorf("Expected content did not match golden file. Expected content: %s", string(content))
+		t.Errorf("Content did not match golden file. Content: %s", string(content))
 	}
 }
 

--- a/cmd/golden/namedWorkflow.yaml
+++ b/cmd/golden/namedWorkflow.yaml
@@ -19,7 +19,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
-    - ../dependency
+    - ../dependency/terragrunt.hcl
   dir: example-setup/depender
   workflow: someWorkflow
 version: 3

--- a/cmd/golden/settingRoot.yaml
+++ b/cmd/golden/settingRoot.yaml
@@ -17,6 +17,6 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
-    - ../dependency
+    - ../dependency/terragrunt.hcl
   dir: example-setup/depender
 version: 3

--- a/cmd/golden/withAutoplan.yaml
+++ b/cmd/golden/withAutoplan.yaml
@@ -17,6 +17,6 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
-    - ../dependency
+    - ../dependency/terragrunt.hcl
   dir: example-setup/depender
 version: 3

--- a/cmd/golden/withoutParent.yaml
+++ b/cmd/golden/withoutParent.yaml
@@ -11,6 +11,6 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
-    - ../dependency
+    - ../dependency/terragrunt.hcl
   dir: example-setup/depender
 version: 3


### PR DESCRIPTION
We had problematic cases in our monorepo where we had:

```
someDir:
  | terragrunt.hcl
  dirA:
    | terragrunt.hcl (depends on ..)
  dirB:
    | terragrunt.hcl (depends on ..)
```

This was problematic because updating dirB would cause dirA to be included in the atlantis plan, because dirA depends on _any_ file in its parent directory, not just the terragrunt.hcl file it's meant to.