### PR TITLE
Feature: build container image and push to public repo

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,67 @@
+# only run when we push changes to master or PRs
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+env:
+  # GitHub Packages docker registry hostname
+  GPR_HOSTNAME: docker.pkg.github.com
+
+jobs:
+  build_with_action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Craft a valid tag for this build
+        id: craft_tag
+        run: >
+          echo -n "::set-output name=image_tag::";
+          echo ${{ github.ref }}
+          | sed -E -e 's/refs\/(heads|tags)?\/?//'
+          -e 's/\//-/g'
+          -e 's/master/latest/'
+
+      - name: Check for an existing build for this ref
+        id: image_check
+        env:
+          URL: https://${{ env.GPR_HOSTNAME }}/v2/${{ github.repository }}/slim/manifests/${{ steps.craft_tag.outputs.image_tag }}
+          CREDS: ${{ github.actor }}:${{ github.token }}
+        run: |
+          echo -n "::set-output name=status_code::"
+          curl -o /dev/null -s -w '%{http_code}\n' -X GET $URL -u $CREDS
+
+      # this step compensates for a limitation of BuildKit + GPR
+      # https://github.com/containerd/containerd/issues/3291
+      - name: Pull an image to use for cache
+        run: |
+          # do we already have this tag in the repo? then pull it
+          if [[ "${{ steps.image_check.outputs.status_code }}" == "200" ]]; then
+            pull_tag=${{ steps.craft_tag.outputs.image_tag }}
+
+          # otherwise pull latest
+          else
+            pull_tag=latest
+          fi
+
+          echo ${{ github.token }} | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+          docker pull ${{ env.GPR_HOSTNAME }}/${{ github.repository }}/slim:$pull_tag
+
+      - name: Build with cache
+        uses: docker/build-push-action@v1
+        env:
+          # use BuildKit to speed up builds and improve caching
+          DOCKER_BUILDKIT: 1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+          registry: ${{ env.GPR_HOSTNAME }}
+          repository: ${{ github.repository }}/slim
+          tags: ${{ steps.craft_tag.outputs.image_tag }}
+          build_args: BUILDKIT_INLINE_CACHE=1
+          tag_with_sha: true
+          cache_froms: >
+            ${{ env.GPR_HOSTNAME }}/${{ github.repository }}/slim:latest,
+            ${{ env.GPR_HOSTNAME }}/${{ github.repository }}/slim:${{ steps.craft_tag.outputs.image_tag }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -62,7 +62,6 @@ jobs:
           repository: ${{ github.repository }}/slim
           tags: ${{ steps.craft_tag.outputs.image_tag }}
           build_args: BUILDKIT_INLINE_CACHE=1
-          tag_with_sha: true
           cache_froms: >
             ${{ env.GPR_HOSTNAME }}/${{ github.repository }}/slim:latest,
             ${{ env.GPR_HOSTNAME }}/${{ github.repository }}/slim:${{ steps.craft_tag.outputs.image_tag }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,6 +2,7 @@
 on:
   push:
     branches: [master]
+    tags: ["*"]
   pull_request:
     branches: [master]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
 # create super thin container with the binary only
 FROM scratch
 COPY --from=build /app/terragrunt-atlantis-config /terragrunt-atlantis-config
-ENTRYPOINT [ "terragrunt-atlantis-config" ]
+ENTRYPOINT [ "/app/terragrunt-atlantis-config" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang AS build
+
+ENV GO111MODULE=on
+WORKDIR /app
+
+# copy source
+COPY go.mod go.sum main.go ./
+COPY cmd ./cmd
+
+# fetch deps separately (for layer caching)
+RUN go mod download
+
+
+# build the executable
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
+
+
+# create super thin container with the binary only
+FROM scratch
+COPY --from=build /app/terragrunt-atlantis-config /terragrunt-atlantis-config
+ENTRYPOINT [ "terragrunt-atlantis-config" ]


### PR DESCRIPTION
Hello again!

I propose here a CI/CD change creating a container image pipeline.

# Use case
To provide a binary package which is easy to consume in container-friendly environments.  For us, it's super handy to use with GitHub Actions because **skipping the build steps reduces run duration from ~2min to ~30s**.

# What does it do?

## On push to PR
1. Build container image (w/caching via BuildKit and Github Packages docker registry)
2. Tag container with PR ref (eg `pull-42-merge`)
3. Push container image to GitHub Packages to be use for further caching

## On push to master
1. Build container image (w/caching via BuildKit and Github Packages docker registry)
2. Tag container with `latest`
3. Push container image to GitHub Packages

## On create tag on master
1. Build container image (w/caching via BuildKit and Github Packages docker registry)
2. Tag container with git tag (eg `v0.6.1`)
3. Push container image to GitHub Packages

## Why all this GitHub stuff?
Well, just because I know it pretty well and its free for public repos 😅   I'm happy to rewrite this stuff with different tools