### PR TITLE
Fix the copy-to dir in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,5 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
 
 # create super thin container with the binary only
 FROM scratch
-COPY --from=build /app/terragrunt-atlantis-config /terragrunt-atlantis-config
+COPY --from=build /app/terragrunt-atlantis-config /app/terragrunt-atlantis-config
 ENTRYPOINT [ "/app/terragrunt-atlantis-config" ]


### PR DESCRIPTION
Woops, the `COPY` line in the Dockerfile has an incorrect destination path. This explains why I keep having to override the `ENTRYPOINT` when running this container 🤦