### PR TITLE
Add option to specify workspace name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,9 @@ build: clean
     -build-ldflags "-X main.VERSION=$(VERSION)"
 
 test:
+	mkdir -p cmd/test_artifacts
 	go test -v ./...
+	rm -rf cmd/test_artifacts
 
 version:
 	@echo $(VERSION)

--- a/README.md
+++ b/README.md
@@ -152,6 +152,37 @@ jobs:
 
 You can customize the version and flags you typically pass to the `generate` command in those final two lines.
 
+## Separate workspace for parallel plan and apply
+Atlantis added support for running plan and apply parallel in [v0.13.0](https://github.com/runatlantis/atlantis/releases/tag/v0.13.0).
+To use this feature, projects has to be separated in different workspaces,
+`createWorkspace` flag enables this by concatenating the project path as the
+name of the workspace, eg: project `${git_root}/stage/app/terragrunt.hcl` will
+have the name `stage_app` as workspace name. This flag needs to be used along with
+`parallel` to enable parallel plan and apply:
+
+```
+terragrunt-atlantis-config generate --output atlantis.yaml --ignore-parent-terragrunt --workflow terragrunt --autoplan=false --parallel=true --createWorkspace=true
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+  dir: stage/app
+  workflow: terragrunt
+  workspace: stage_app
+```
+
+---
+***NOTE:***
+
+Enable this feature may consume more resources like cpu, memory, network and disk,
+as multiple projects are being processed at the same time.
+
+---
+
 ## Contributing
 
 To test any changes you've made, run `make test`.

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -161,3 +161,11 @@ func TestUnparseableParent(t *testing.T) {
 		"--ignore-parent-terragrunt",
 	})
 }
+
+func TestWithWorkspaces(t *testing.T) {
+	runTest(t, filepath.Join("golden", "withWorkspace.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "basic_module"),
+		"--createWorkspace=true",
+	})
+}

--- a/cmd/golden/withWorkspace.yaml
+++ b/cmd/golden/withWorkspace.yaml
@@ -1,0 +1,12 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: .
+  workspace: _
+version: 3


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- _[none]_

## Description
Per the comments in the issue https://github.com/runatlantis/atlantis/issues/260 , atlantis locks the project based on the workspace name, parallel plan on different directories will fail with the error `the default workspace is currently locked by another command that is running for this pull request–wait until the previous command is complete and try again`.

This add an option to specify the workspace for each project with their path:
```
projects:
- autoplan:
    enabled: false
    when_modified:
    - '*.hcl'
    - '*.tf*'
    - ./aws/prod/s3/terragrunt.hcl
    - ./module/aws*.tf*
  dir: aws/prod/s3
  workflow: terragrunt
  workspace: aws_prod_s3
```

## Security Implications

- _[none]_

## System Availability

- _[none]_
