### PR TITLE
Support the addition of each Project Name in atlantis.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,40 @@
+##############################
+########### Custom ###########
+##############################
+.vscode/
+build
+test_artifacts
+
+# IDEs
+.vscode
+*.sublime-*
+.idea
+.editorconfig
+.swp
+
+# OS files
+*.DS_Store
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+
+##############################
+# Common gitignore file based on: https://github.com/github/gitignore/blob/master/Go.gitignore
+##############################
 # Binaries for programs and plugins
 *.exe
 *.exe~
 *.dll
 *.so
 *.dylib
-build
 
 # Test binary, built with `go test -c`
 *.test
-test_artifacts
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
+# Dependency directories (add a comment below to exclude it)
+ vendor

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.7.0
+VERSION=0.8.0
 PATH_BUILD=build/
 FILE_COMMAND=terragrunt-atlantis-config
 FILE_ARCH=darwin_amd64

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ terragrunt-atlantis-config generate --workflow web --output ./atlantis.yaml
 
 # ignore parent terragrunt configs (those which don't reference a terraform module)
 terragrunt-atlantis-config generate --ignore-parent-terragrunt
+
+# Enable the project name creation
+terragrunt-atlantis-config generate --create-project-name
 ```
 
 Finally, check the log output (or your output file) for the YAML.
@@ -168,6 +171,9 @@ terragrunt-atlantis-config generate --output atlantis.yaml --parallel --create-w
 ```
 
 Enabling this feature may consume more resources like cpu, memory, network, and disk, as each workspace will now be cloned separately by atlantis.
+
+As when defining the workspace this info is also needed when running `atlantis plan/apply -d ${git_root}/stage/app -w stage_app` to run the command on specific directory,
+you can also use the `atlantis plan/apply -p stage_app` in case you have enabled the `create-project-name` cli argument (it is `false` by default).
 
 ## Contributing
 

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -169,3 +169,11 @@ func TestWithWorkspaces(t *testing.T) {
 		"--create-workspace",
 	})
 }
+
+func TestWithProjectNames(t *testing.T) {
+	runTest(t, filepath.Join("golden", "withProjectName.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "invalid_parent_module"),
+		"--ignore-parent-terragrunt",  "--create-project-name",
+	})
+}

--- a/cmd/golden/withProjectName.yaml
+++ b/cmd/golden/withProjectName.yaml
@@ -1,0 +1,12 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: .
+  workspace: _
+version: 3

--- a/cmd/golden/withProjectName.yaml
+++ b/cmd/golden/withProjectName.yaml
@@ -7,6 +7,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
-  dir: .
-  workspace: _
+  dir: child/deep
+  name: child_deep
+  workspace: child_deep
 version: 3

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import "github.com/transcend-io/terragrunt-atlantis-config/cmd"
 
 var (
-	VERSION = "0.7.0"
+	VERSION = "0.8.0"
 )
 
 func main() {


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- _[none]_

## Description

As when defining different workspaces for each directory,
this info is also needed when running `atlantis plan/apply -d ${git_root}/stage/app -w stage_app`
to run the command on specific directory but one could also use the
`atlantis plan/apply -p stage_app` in case there is a project name defined.
As this uses the same convention with the name of workspace (which should
be unique) and the default value is disabled this should not create any
problems to the current users.

## Security Implications

- _[none]_

## System Availability

- _[none]_
