### PR TITLE
Inherit locals from parent terragrunt files

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -123,9 +123,13 @@ func getDependencies(path string) ([]string, error) {
 		return nil, err
 	}
 
-	dependencies, err := parseLocalDependencies(path)
+	locals, err := parseLocals(path)
 	if err != nil {
 		return nil, err
+	}
+	dependencies := []string{}
+	if locals.ExtraAtlantisDependencies != nil {
+		dependencies = locals.ExtraAtlantisDependencies
 	}
 
 	if parsedConfig.Dependencies != nil {
@@ -151,8 +155,9 @@ func createProject(sourcePath string) (*AtlantisProject, error) {
 	if err != nil {
 		return nil, err
 	}
-	// if dependencies AND err is nil then return nils to indicate we should skip this project
-	if err == nil && dependencies == nil {
+	// dependencies being nil is a sign from `getDependencies` that this project should be skipped
+	// DO NOT SUBMIT: Make this clearer in code
+	if dependencies == nil {
 		return nil, nil
 	}
 
@@ -187,9 +192,8 @@ func createProject(sourcePath string) (*AtlantisProject, error) {
 	}
 
 	workflow := defaultWorkflow
-	workflowValue, ok := locals["atlantis_workflow"]
-	if ok {
-		workflow = workflowValue.AsString()
+	if locals.AtlantisWorkflow != "" {
+		workflow = locals.AtlantisWorkflow
 	}
 
 	project := &AtlantisProject{

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -156,7 +156,6 @@ func createProject(sourcePath string) (*AtlantisProject, error) {
 		return nil, err
 	}
 	// dependencies being nil is a sign from `getDependencies` that this project should be skipped
-	// DO NOT SUBMIT: Make this clearer in code
 	if dependencies == nil {
 		return nil, nil
 	}

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-// Resets all flag values to their defaults
+// Resets all flag values to their defaults in between tests
 func resetDefaultFlags() error {
 	pwd, err := os.Getwd()
 	if err != nil {
@@ -16,8 +16,10 @@ func resetDefaultFlags() error {
 
 	gitRoot = pwd
 	autoPlan = false
-	parallel = true
 	ignoreParentTerragrunt = false
+	parallel = true
+	createWorkspace = false
+	createProjectName = false
 	defaultWorkflow = ""
 	outputPath = ""
 
@@ -174,6 +176,30 @@ func TestWithProjectNames(t *testing.T) {
 	runTest(t, filepath.Join("golden", "withProjectName.yaml"), []string{
 		"--root",
 		filepath.Join("..", "test_examples", "invalid_parent_module"),
-		"--ignore-parent-terragrunt",  "--create-project-name",
+		"--ignore-parent-terragrunt", "--create-project-name",
+	})
+}
+
+func TestMergingLocalDependenciesFromParent(t *testing.T) {
+	runTest(t, filepath.Join("golden", "mergeParentDependencies.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "parent_with_extra_deps"),
+		"--ignore-parent-terragrunt",
+	})
+}
+
+func TestWorkflowFromParentInLocals(t *testing.T) {
+	runTest(t, filepath.Join("golden", "parentDefinedWorkflow.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "parent_with_workflow_local"),
+		"--ignore-parent-terragrunt",
+	})
+}
+
+func TestChildWorkflowOverridesParentWorkflow(t *testing.T) {
+	runTest(t, filepath.Join("golden", "parentAndChildDefinedWorkflow.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "child_and_parent_specify_workflow"),
+		"--ignore-parent-terragrunt",
 	})
 }

--- a/cmd/golden/mergeParentDependencies.yaml
+++ b/cmd/golden/mergeParentDependencies.yaml
@@ -7,6 +7,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
-  dir: child/deep
-  name: child_deep
+    - some_parent_dep
+    - some_child_dep
+  dir: child
 version: 3

--- a/cmd/golden/parentAndChildDefinedWorkflow.yaml
+++ b/cmd/golden/parentAndChildDefinedWorkflow.yaml
@@ -7,6 +7,6 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
-  dir: child/deep
-  name: child_deep
+  dir: child
+  workflow: workflowSpecifiedInChild
 version: 3

--- a/cmd/golden/parentDefinedWorkflow.yaml
+++ b/cmd/golden/parentDefinedWorkflow.yaml
@@ -7,6 +7,6 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
-  dir: child/deep
-  name: child_deep
+  dir: child
+  workflow: workflowSpecifiedInParent
 version: 3

--- a/cmd/parse_locals.go
+++ b/cmd/parse_locals.go
@@ -43,7 +43,7 @@ func parseHcl(parser *hclparse.Parser, hcl string, filename string) (file *hcl.F
 	return file, nil
 }
 
-// DO NOT SUBMIT: memoize so that this is only done once per path per run
+// TODO: memoize so that this is only done once per path per run
 // Parses a given file, returning a map of all it's `local` values
 func parseLocals(path string) (ResolvedLocals, error) {
 	configString, err := util.ReadFileAsString(path)

--- a/cmd/parse_locals.go
+++ b/cmd/parse_locals.go
@@ -15,6 +15,15 @@ import (
 	"path/filepath"
 )
 
+// ResolvedLocals are the parsed result of local values this module cares about
+type ResolvedLocals struct {
+	// The Atlantis workflow to use for some project
+	AtlantisWorkflow string
+
+	// Extra dependencies that can be hardcoded in config
+	ExtraAtlantisDependencies []string
+}
+
 // parseHcl uses the HCL2 parser to parse the given string into an HCL file body.
 func parseHcl(parser *hclparse.Parser, hcl string, filename string) (file *hcl.File, err error) {
 	if filepath.Ext(filename) == ".json" {
@@ -34,59 +43,79 @@ func parseHcl(parser *hclparse.Parser, hcl string, filename string) (file *hcl.F
 	return file, nil
 }
 
+// DO NOT SUBMIT: memoize so that this is only done once per path per run
 // Parses a given file, returning a map of all it's `local` values
-func parseLocals(path string) (map[string]cty.Value, error) {
+func parseLocals(path string) (ResolvedLocals, error) {
 	configString, err := util.ReadFileAsString(path)
 	if err != nil {
-		return nil, err
+		return ResolvedLocals{}, err
 	}
 
 	options, err := options.NewTerragruntOptions(path)
 	if err != nil {
-		return nil, err
+		return ResolvedLocals{}, err
 	}
 
 	// Parse the HCL string into an AST body
 	parser := hclparse.NewParser()
 	file, err := parseHcl(parser, configString, path)
 	if err != nil {
-		return nil, err
+		return ResolvedLocals{}, err
 	}
 
 	// Decode just the Base blocks. See the function docs for DecodeBaseBlocks for more info on what base blocks are.
-	localsAsCty, _, _, err := config.DecodeBaseBlocks(options, parser, file, path, nil)
+	localsAsCty, _, includeConfig, err := config.DecodeBaseBlocks(options, parser, file, path, nil)
 	if err != nil {
-		return nil, err
+		return ResolvedLocals{}, err
 	}
 
-	// If there are no locals, return early
-	if *localsAsCty == cty.NilVal {
-		return map[string]cty.Value{}, nil
+	// Recurse on the parent to merge in the locals from that file
+	parentLocals := ResolvedLocals{}
+	if includeConfig != nil {
+		// Ignore errors if the parent cannot be parsed
+		parentLocals, _ = parseLocals(includeConfig.Path)
 	}
 
-	return localsAsCty.AsValueMap(), nil
+	childLocals := resolveLocals(*localsAsCty)
+	if childLocals.AtlantisWorkflow != "" {
+		parentLocals.AtlantisWorkflow = childLocals.AtlantisWorkflow
+	}
+
+	for _, dep := range childLocals.ExtraAtlantisDependencies {
+		parentLocals.ExtraAtlantisDependencies = append(
+			parentLocals.ExtraAtlantisDependencies,
+			dep,
+		)
+	}
+
+	return parentLocals, nil
 }
 
-// Parses the terragrunt config at <path> to find any `locals` values with
-// the name `extra_atlantis_dependencies`
-func parseLocalDependencies(path string) ([]string, error) {
-	locals, err := parseLocals(path)
-	if err != nil {
-		return nil, err
+func resolveLocals(localsAsCty cty.Value) ResolvedLocals {
+	resolved := ResolvedLocals{}
+
+	// Return an empty set of locals if no `locals` block was present
+	if localsAsCty == cty.NilVal {
+		return resolved
+	}
+	rawLocals := localsAsCty.AsValueMap()
+
+	workflowValue, ok := rawLocals["atlantis_workflow"]
+	if ok {
+		resolved.AtlantisWorkflow = workflowValue.AsString()
 	}
 
-	extraDependenciesAsCty, ok := locals["extra_atlantis_dependencies"]
-	if !ok {
-		return []string{}, nil
+	extraDependenciesAsCty, ok := rawLocals["extra_atlantis_dependencies"]
+	if ok {
+		it := extraDependenciesAsCty.ElementIterator()
+		for it.Next() {
+			_, val := it.Element()
+			resolved.ExtraAtlantisDependencies = append(
+				resolved.ExtraAtlantisDependencies,
+				filepath.ToSlash(val.AsString()),
+			)
+		}
 	}
 
-	dependencies := []string{}
-
-	it := extraDependenciesAsCty.ElementIterator()
-	for it.Next() {
-		_, val := it.Element()
-		dependencies = append(dependencies, filepath.ToSlash(val.AsString()))
-	}
-
-	return dependencies, nil
+	return resolved
 }

--- a/go.sum
+++ b/go.sum
@@ -762,6 +762,7 @@ github.com/zclconf/go-cty v1.3.1/go.mod h1:YO23e2L18AG+ZYQfSobnY4G65nvwvprPCxBHk
 github.com/zclconf/go-cty v1.5.0 h1:U0USwJxGTnUd+dT565f92paYOlRtd201pI7+ZGW36XY=
 github.com/zclconf/go-cty v1.5.1 h1:oALUZX+aJeEBUe2a1+uD2+UTaYfEjnKFDEMRydkGvWE=
 github.com/zclconf/go-cty v1.5.1/go.mod h1:nHzOclRkoj++EU9ZjSrZvRG0BXIWt8c7loYc0qXAFGQ=
+github.com/zclconf/go-cty v1.6.1 h1:wHtZ+LSSQVwUSb+XIJ5E9hgAQxyWATZsAWT+ESJ9dQ0=
 github.com/zclconf/go-cty-yaml v1.0.1 h1:up11wlgAaDvlAGENcFDnZgkn0qUJurso7k6EpURKNF8=
 github.com/zclconf/go-cty-yaml v1.0.1/go.mod h1:IP3Ylp0wQpYm50IHK8OZWKMu6sPJIUgKa8XhiVHura0=
 github.com/zclconf/go-cty-yaml v1.0.2 h1:dNyg4QLTrv2IfJpm7Wtxi55ed5gLGOlPrZ6kMd51hY0=

--- a/test_examples/child_and_parent_specify_workflow/child/terragrunt.hcl
+++ b/test_examples/child_and_parent_specify_workflow/child/terragrunt.hcl
@@ -1,0 +1,15 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+locals {
+  atlantis_workflow = "workflowSpecifiedInChild"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/child_and_parent_specify_workflow/terragrunt.hcl
+++ b/test_examples/child_and_parent_specify_workflow/terragrunt.hcl
@@ -1,0 +1,3 @@
+locals {
+  atlantis_workflow = "workflowSpecifiedInParent"
+}

--- a/test_examples/parent_with_extra_deps/child/terragrunt.hcl
+++ b/test_examples/parent_with_extra_deps/child/terragrunt.hcl
@@ -1,0 +1,17 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+locals {
+  extra_atlantis_dependencies = [
+    "some_child_dep",
+  ]
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/parent_with_extra_deps/terragrunt.hcl
+++ b/test_examples/parent_with_extra_deps/terragrunt.hcl
@@ -1,0 +1,5 @@
+locals {
+  extra_atlantis_dependencies = [
+    "some_parent_dep",
+  ]
+}

--- a/test_examples/parent_with_workflow_local/child/terragrunt.hcl
+++ b/test_examples/parent_with_workflow_local/child/terragrunt.hcl
@@ -1,0 +1,11 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/parent_with_workflow_local/terragrunt.hcl
+++ b/test_examples/parent_with_workflow_local/terragrunt.hcl
@@ -1,0 +1,3 @@
+locals {
+  atlantis_workflow = "workflowSpecifiedInParent"
+}


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- https://github.com/transcend-io/terragrunt-atlantis-config/issues/59
- https://github.com/transcend-io/terragrunt-atlantis-config/issues/46

## Description

There have been a few mentions in issues that people would prefer to not have to add `locals` to all their child terragrunt.hcl files, which makes sense. One way to make this more manageable is to allow specifying locals in parent files that get passed down to children.

This PR adds in that functionality:
- Workflow names will be prioritized by: child workflow local -> parent workflow local -> default from flag
- extra dependencies will be combined between parents and children
