### PR TITLE
Allow using hardcoded version as default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.9.0
+VERSION=0.9.1
 PATH_BUILD=build/
 FILE_COMMAND=terragrunt-atlantis-config
 FILE_ARCH=darwin_amd64

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ jobs:
         id: atlantis_validator
         uses: transcend-io/terragrunt-atlantis-config-github-action@v0.0.3
         with:
-          version: v0.9.0
+          version: v0.9.1
           extra_args: '--autoplan --parallel=false
 ```
 

--- a/main.go
+++ b/main.go
@@ -2,9 +2,10 @@ package main
 
 import "github.com/transcend-io/terragrunt-atlantis-config/cmd"
 
-// This variable is set at build time using -ldflags parameters. For more info, see:
-// http://stackoverflow.com/a/11355611/483528
-var VERSION string
+// This variable is set at build time using -ldflags parameters.
+// But we still set a default here for those using plain `go get` downloads
+// For more info, see: http://stackoverflow.com/a/11355611/483528
+var VERSION string = "0.9.1"
 
 func main() {
 	cmd.Execute(VERSION)


### PR DESCRIPTION
# Pull Request

## Description

Running a command like:

```bash
GOPRIVATE=github.com/transcend-io GO111MODULE=on go get github.com/transcend-io/terragrunt-atlantis-config@v0.9.0
terragrunt-atlantis-config version
```

would print out an empty version, because ldflags were not used during the build step of the install. While ldflags can be passed to `go get`, I think that having the version hardcoded into the application code such that the version will always display is a good idea.
