### PR TITLE
Fix bug with parsing extra arguments

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -154,11 +154,15 @@ func getDependencies(path string) ([]string, error) {
 	if parsedConfig.Terraform != nil && parsedConfig.Terraform.ExtraArgs != nil {
 		extraArgs := parsedConfig.Terraform.ExtraArgs
 		for _, arg := range extraArgs {
-			for _, file := range *arg.RequiredVarFiles {
-				dependencies = append(dependencies, file)
+			if arg.RequiredVarFiles != nil {
+				for _, file := range *arg.RequiredVarFiles {
+					dependencies = append(dependencies, file)
+				}
 			}
-			for _, file := range *arg.OptionalVarFiles {
-				dependencies = append(dependencies, file)
+			if arg.OptionalVarFiles != nil {
+				for _, file := range *arg.OptionalVarFiles {
+					dependencies = append(dependencies, file)
+				}
 			}
 		}
 	}

--- a/cmd/golden/extraArguments.yaml
+++ b/cmd/golden/extraArguments.yaml
@@ -13,4 +13,27 @@ projects:
     - dev.tfvars
     - us-east-1.tfvars
   dir: child
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: no_files_at_all
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../dev.tfvars
+    - ../us-east-1.tfvars
+    - dev.tfvars
+    - us-east-1.tfvars
+  dir: only_optional_files
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../terraform.tfvars
+  dir: only_required_files
 version: 3

--- a/test_examples/extra_arguments/no_files_at_all/terragrunt.hcl
+++ b/test_examples/extra_arguments/no_files_at_all/terragrunt.hcl
@@ -1,0 +1,20 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+  extra_arguments "conditional_vars" {
+    commands = [
+      "apply",
+      "plan",
+      "import",
+      "push",
+      "refresh"
+    ]
+  }
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/extra_arguments/only_optional_files/terragrunt.hcl
+++ b/test_examples/extra_arguments/only_optional_files/terragrunt.hcl
@@ -1,0 +1,30 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+  extra_arguments "conditional_vars" {
+    commands = [
+      "apply",
+      "plan",
+      "import",
+      "push",
+      "refresh"
+    ]
+
+    # Small note: get_env can't really be supported very well here.
+    # In a case like this, I'd use a for loop to construct
+    # `extra_atlantis_dependencies` in locals for all possible regions
+    optional_var_files = [
+      "${get_parent_terragrunt_dir()}/${get_env("TF_VAR_env", "dev")}.tfvars",
+      "${get_parent_terragrunt_dir()}/${get_env("TF_VAR_region", "us-east-1")}.tfvars",
+      "${get_terragrunt_dir()}/${get_env("TF_VAR_env", "dev")}.tfvars",
+      "${get_terragrunt_dir()}/${get_env("TF_VAR_region", "us-east-1")}.tfvars"
+    ]
+  }
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/extra_arguments/only_required_files/terragrunt.hcl
+++ b/test_examples/extra_arguments/only_required_files/terragrunt.hcl
@@ -1,0 +1,24 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+  extra_arguments "conditional_vars" {
+    commands = [
+      "apply",
+      "plan",
+      "import",
+      "push",
+      "refresh"
+    ]
+
+    required_var_files = [
+      "${get_parent_terragrunt_dir()}/terraform.tfvars"
+    ]
+  }
+}
+
+inputs = {
+  foo = "bar"
+}


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- https://github.com/transcend-io/terragrunt-atlantis-config/issues/66

## Description

Fixes issue where `extra_argument` blocks without required or optional fields specified caused a golang panic because of a segmentation fault when dereferencing a null pointer.

Relevant: https://www.youtube.com/watch?v=bLHL75H_VEM
