### PR TITLE
Add support for `-var-file` extra_arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.9.3
+VERSION=0.9.4
 PATH_BUILD=build/
 FILE_COMMAND=terragrunt-atlantis-config
 FILE_ARCH=darwin_amd64

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ jobs:
         id: atlantis_validator
         uses: transcend-io/terragrunt-atlantis-config-github-action@v0.0.3
         with:
-          version: v0.9.3
+          version: v0.9.4
           extra_args: '--autoplan --parallel=false
 ```
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -164,6 +164,13 @@ func getDependencies(path string) ([]string, error) {
 					dependencies = append(dependencies, file)
 				}
 			}
+			if arg.Arguments != nil {
+				for _, cliFlag := range *arg.Arguments {
+					if strings.HasPrefix(cliFlag, "-var-file=") {
+						dependencies = append(dependencies, strings.TrimPrefix(cliFlag, "-var-file="))
+					}
+				}
+			}
 		}
 	}
 

--- a/cmd/golden/extraArguments.yaml
+++ b/cmd/golden/extraArguments.yaml
@@ -36,4 +36,12 @@ projects:
     - '*.tf*'
     - ../terraform.tfvars
   dir: only_required_files
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../../common_vars/apps/consul/sg.tfvars
+    - main.tfvars
+  dir: var_file
 version: 3

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import "github.com/transcend-io/terragrunt-atlantis-config/cmd"
 // This variable is set at build time using -ldflags parameters.
 // But we still set a default here for those using plain `go get` downloads
 // For more info, see: http://stackoverflow.com/a/11355611/483528
-var VERSION string = "0.9.3"
+var VERSION string = "0.9.4"
 
 func main() {
 	cmd.Execute(VERSION)

--- a/test_examples/extra_arguments/var_file/terragrunt.hcl
+++ b/test_examples/extra_arguments/var_file/terragrunt.hcl
@@ -1,0 +1,25 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+  extra_arguments "conditional_vars" {
+    commands = [
+      "apply",
+      "plan",
+      "import",
+      "push",
+      "refresh"
+    ]
+
+    arguments = [
+      "-var-file=${get_terragrunt_dir()}/../../../../common_vars/apps/consul/sg.tfvars",
+      "-var-file=${get_terragrunt_dir()}/main.tfvars"
+    ]
+  }
+}
+
+inputs = {
+  foo = "bar"
+}


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- https://github.com/transcend-io/terragrunt-atlantis-config/issues/60

## Description

Add support for `-var-file` extra_arguments in the `arguments` subfield.
