### PR TITLE
Have parent dependencies be relative to the child

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.9.4
+VERSION=0.9.5
 PATH_BUILD=build/
 FILE_COMMAND=terragrunt-atlantis-config
 FILE_ARCH=darwin_amd64

--- a/README.md
+++ b/README.md
@@ -99,7 +99,11 @@ In your `atlantis.yaml` file, you will end up seeing output like:
   dir: example-setup/extra_dependency
 ```
 
-If you specify `extra_atlantis_dependencies` in the parent Terragrunt module, they will be merged with the child dependencies.
+If you specify `extra_atlantis_dependencies` in the parent Terragrunt module, they will be merged with the child dependencies using the following rules:
+
+1. Any function in a parent will be evaluated from the child's directory. So you can use `get_parent_terragrunt_dir()` and other functions like you normally would in terragrunt.
+2. Absolute paths will work as they would in a child module, and the path in the output will be relative from the child module to the absolute path
+3. Relative paths, like the string `"foo.json"`, will be evaluated as relative to the Child module. This means that if you need something relative to the parent module, you should use something like `"${get_parent_terragrunt_dir()}/foo.json"`
 
 ## Custom workflows
 
@@ -154,7 +158,7 @@ jobs:
         id: atlantis_validator
         uses: transcend-io/terragrunt-atlantis-config-github-action@v0.0.3
         with:
-          version: v0.9.4
+          version: v0.9.5
           extra_args: '--autoplan --parallel=false
 ```
 

--- a/cmd/golden/mergeParentDependencies.yaml
+++ b/cmd/golden/mergeParentDependencies.yaml
@@ -8,6 +8,8 @@ projects:
     - '*.hcl'
     - '*.tf*'
     - some_parent_dep
+    - ../file_in_parent_of_child.json
+    - ../../parent/folder_under_parent/common_tags.hcl
     - some_child_dep
-  dir: child
+  dir: deep/child
 version: 3

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import "github.com/transcend-io/terragrunt-atlantis-config/cmd"
 // This variable is set at build time using -ldflags parameters.
 // But we still set a default here for those using plain `go get` downloads
 // For more info, see: http://stackoverflow.com/a/11355611/483528
-var VERSION string = "0.9.4"
+var VERSION string = "0.9.5"
 
 func main() {
 	cmd.Execute(VERSION)

--- a/test_examples/parent_with_extra_deps/deep/child/terragrunt.hcl
+++ b/test_examples/parent_with_extra_deps/deep/child/terragrunt.hcl
@@ -1,5 +1,5 @@
 include {
-  path = find_in_parent_folders()
+  path = "${find_in_parent_folders("parent")}/terragrunt.hcl"
 }
 
 terraform {

--- a/test_examples/parent_with_extra_deps/deep/file_in_parent_of_child.json
+++ b/test_examples/parent_with_extra_deps/deep/file_in_parent_of_child.json
@@ -1,0 +1,3 @@
+{
+    "noice": "no ice"
+}

--- a/test_examples/parent_with_extra_deps/parent/folder_under_parent/common_tags.hcl
+++ b/test_examples/parent_with_extra_deps/parent/folder_under_parent/common_tags.hcl
@@ -1,0 +1,3 @@
+inputs = {
+    nice = "dog"
+}

--- a/test_examples/parent_with_extra_deps/parent/terragrunt.hcl
+++ b/test_examples/parent_with_extra_deps/parent/terragrunt.hcl
@@ -1,0 +1,10 @@
+locals {
+  extra_atlantis_dependencies = [
+    # A relative file to the child should work
+    "some_parent_dep",
+
+    # Functions should run from the child dir, not the parent dir
+    find_in_parent_folders("file_in_parent_of_child.json"),
+    "${get_parent_terragrunt_dir()}/folder_under_parent/common_tags.hcl",
+  ]
+}

--- a/test_examples/parent_with_extra_deps/terragrunt.hcl
+++ b/test_examples/parent_with_extra_deps/terragrunt.hcl
@@ -1,5 +1,0 @@
-locals {
-  extra_atlantis_dependencies = [
-    "some_parent_dep",
-  ]
-}


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- https://github.com/transcend-io/terragrunt-atlantis-config/issues/60#issuecomment-702076380

## Description

Updates the parsing of parent terragrunt modules so that they are evaluated from the point of view of the child directories.

Added more testing and updated the documentation.
