### PR TITLE
Allow preserving old workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ it will have `workflow: workflowA` set in the atlantis.yaml settings.
 
 Workflow names can be specified in either parent or child terragrunt modules, but if both are specified then this module will use the workflow name specified from the child.
 
+If you write your workflows in your `atlantis.yaml` file, this library will leave them functionally as you already have them.
+
 ## Auto Enforcement with Github Actions
 
 It's a best practice to require that `atlantis.yaml` stays up to date on each Pull Request.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"io/ioutil"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/ghodss/yaml"
+)
+
+// Represents an entire config file
+type AtlantisConfig struct {
+	// Version of the config syntax
+	Version int `json:"version"`
+
+	// If Atlantis should merge after finishing `atlantis apply`
+	AutoMerge bool `json:"automerge"`
+
+	// If Atlantis should allow plans to occur in parallel
+	ParallelPlan bool `json:"parallel_plan"`
+
+	// If Atlantis should allow applies to occur in parallel
+	ParallelApply bool `json:"parallel_apply"`
+
+	// The project settings
+	Projects []AtlantisProject `json:"projects,omitempty"`
+
+	// Workflows, which are not managed by this library other than
+	// the fact that this library preserves any existing workflows
+	Workflows interface{} `json:"workflows,omitempty"`
+}
+
+// Represents an Atlantis Project directory
+type AtlantisProject struct {
+	// The directory with the terragrunt.hcl file
+	Dir string `json:"dir"`
+
+	// Define workflow name
+	Workflow string `json:"workflow,omitempty"`
+
+	// Define workspace name
+	Workspace string `json:"workspace,omitempty"`
+
+	// Define project name
+	Name string `json:"name,omitempty"`
+
+	// Autoplan settings for which plans affect other plans
+	Autoplan AutoplanConfig `json:"autoplan"`
+}
+
+// Autoplan settings for which plans affect other plans
+type AutoplanConfig struct {
+	// Relative paths from this modules directory to modules it depends on
+	WhenModified []string `json:"when_modified"`
+
+	// If autoplan should be enabled for this dir
+	Enabled bool `json:"enabled"`
+}
+
+// Checks if an output file already exists. If it does, it reads it
+// in to preserve some parts of the old config
+func readOldConfig() (*AtlantisConfig, error) {
+	// The old file not existing is not an error, as it should not exist on the very first run
+	bytes, err := ioutil.ReadFile(outputPath)
+	if err != nil {
+		log.Warn("Could not find an old config file. Starting from scratch")
+		return nil, nil
+	}
+
+	// The old file being malformed is an actual error
+	config := AtlantisConfig{}
+	err = yaml.Unmarshal(bytes, &config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}

--- a/cmd/golden/oldWorkflowsPreserved.yaml
+++ b/cmd/golden/oldWorkflowsPreserved.yaml
@@ -1,0 +1,19 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: .
+version: 3
+workflows:
+  terragrunt:
+    apply:
+      steps:
+      - run: terragrunt apply -no-color $PLANFILE
+    plan:
+      steps:
+      - run: terragrunt plan -no-color -out $PLANFILE


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- Closes https://github.com/transcend-io/terragrunt-atlantis-config/issues/79

## Description

Allow preserving old workflows. This is a breaking change, but should not affect anyone who already uses this library, so it should be fairly safe to release.
