### PR TITLE
enable atlantis_autoplan local

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -184,11 +184,16 @@ func createProject(sourcePath string) (*AtlantisProject, error) {
 		workflow = locals.AtlantisWorkflow
 	}
 
+	resolvedAutoPlan := autoPlan
+	if locals.AutoPlan != nil {
+		resolvedAutoPlan = *locals.AutoPlan
+	}
+
 	project := &AtlantisProject{
 		Dir:      filepath.ToSlash(relativeSourceDir),
 		Workflow: workflow,
 		Autoplan: AutoplanConfig{
-			Enabled:      autoPlan,
+			Enabled:      resolvedAutoPlan,
 			WhenModified: relativeDependencies,
 		},
 	}

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -233,6 +233,15 @@ func TestInfrastructureLive(t *testing.T) {
 	})
 }
 
+func TestAutoPlan(t *testing.T) {
+	runTest(t, filepath.Join("golden", "autoplan.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "autoplan"),
+		"--ignore-parent-terragrunt",
+		"--autoplan=false",
+	})
+}
+
 func TestPreservingOldWorkflows(t *testing.T) {
 	err := resetDefaultFlags()
 	if err != nil {

--- a/cmd/golden/autoplan.yaml
+++ b/cmd/golden/autoplan.yaml
@@ -1,0 +1,23 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: autoplan_false
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: autoplan_true
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: set_in_parent
+version: 3

--- a/test_examples/autoplan/autoplan_false/terragrunt.hcl
+++ b/test_examples/autoplan/autoplan_false/terragrunt.hcl
@@ -1,0 +1,15 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+locals {
+  atlantis_autoplan = false
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/autoplan/autoplan_true/terragrunt.hcl
+++ b/test_examples/autoplan/autoplan_true/terragrunt.hcl
@@ -1,0 +1,15 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+locals {
+  atlantis_autoplan = true
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/autoplan/set_in_parent/terragrunt.hcl
+++ b/test_examples/autoplan/set_in_parent/terragrunt.hcl
@@ -1,0 +1,11 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/autoplan/terragrunt.hcl
+++ b/test_examples/autoplan/terragrunt.hcl
@@ -1,0 +1,3 @@
+locals {
+  atlantis_autoplan = true
+}


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- https://github.com/transcend-io/terragrunt-atlantis-config/issues/84

## Description

enables setting `atlantis_autoplan` in any parent or child terragrunt file