### PR TITLE
Support custom terraform versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ One way to customize the behavior of this module is through CLI flag values pass
 | `--workflow`                 | Name of the workflow to be customized in the atlantis server. If empty, will be left out of output                                         | ""                |
 | `--output`                   | Path of the file where configuration will be generated. Typically, you want a file named "atlantis.yaml". Default is to write to `stdout`. | ""                |
 | `--root`                     | Path to the root directory of the git repo you want to build config for.                                                                   | current directory |
+| `--terraform-version`        | Default terraform version to specify for all modules. Can be overriden by locals                                                           | ""                |
 
 ## All Locals
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -46,6 +46,9 @@ type AtlantisProject struct {
 
 	// Autoplan settings for which plans affect other plans
 	Autoplan AutoplanConfig `json:"autoplan"`
+
+	// The terraform version to use for this project
+	TerraformVersion string `json:"terraform_version,omitempty"`
 }
 
 // Autoplan settings for which plans affect other plans

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -194,9 +194,15 @@ func createProject(sourcePath string) (*AtlantisProject, error) {
 		resolvedAutoPlan = *locals.AutoPlan
 	}
 
+	terraformVersion := defaultTerraformVersion
+	if locals.TerraformVersion != "" {
+		terraformVersion = locals.TerraformVersion
+	}
+
 	project := &AtlantisProject{
-		Dir:      filepath.ToSlash(relativeSourceDir),
-		Workflow: workflow,
+		Dir:              filepath.ToSlash(relativeSourceDir),
+		Workflow:         workflow,
+		TerraformVersion: terraformVersion,
 		Autoplan: AutoplanConfig{
 			Enabled:      resolvedAutoPlan,
 			WhenModified: relativeDependencies,
@@ -328,6 +334,7 @@ var ignoreParentTerragrunt bool
 var parallel bool
 var createWorkspace bool
 var createProjectName bool
+var defaultTerraformVersion string
 var defaultWorkflow string
 var outputPath string
 var preserveWorkflows bool
@@ -357,6 +364,7 @@ func init() {
 	generateCmd.PersistentFlags().StringVar(&defaultWorkflow, "workflow", "", "Name of the workflow to be customized in the atlantis server. Default is to not set")
 	generateCmd.PersistentFlags().StringVar(&outputPath, "output", "", "Path of the file where configuration will be generated. Default is not to write to file")
 	generateCmd.PersistentFlags().StringVar(&gitRoot, "root", pwd, "Path to the root directory of the git repo you want to build config for. Default is current dir")
+	generateCmd.PersistentFlags().StringVar(&defaultTerraformVersion, "terraform-version", "", "Default terraform version to specify for all modules. Can be overriden by locals")
 }
 
 // Runs a set of arguments, returning the output

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -25,6 +25,7 @@ func resetDefaultFlags() error {
 	preserveWorkflows = true
 	defaultWorkflow = ""
 	outputPath = ""
+	defaultTerraformVersion = ""
 
 	return nil
 }
@@ -247,6 +248,15 @@ func TestSkippingModules(t *testing.T) {
 		"--root",
 		filepath.Join("..", "test_examples", "skip"),
 		"--ignore-parent-terragrunt",
+	})
+}
+
+func TestTerraformVersionConfig(t *testing.T) {
+	runTest(t, filepath.Join("golden", "terraform_version.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "terraform_version"),
+		"--ignore-parent-terragrunt",
+		"--terraform-version", "0.14.9001",
 	})
 }
 

--- a/cmd/golden/terraform_version.yaml
+++ b/cmd/golden/terraform_version.yaml
@@ -1,0 +1,26 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: inherit_from_parent
+  terraform_version: 0.12.9001
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: override_parent
+  terraform_version: 0.13.9001
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: use_flag_default
+  terraform_version: 0.14.9001
+version: 3

--- a/cmd/parse_locals.go
+++ b/cmd/parse_locals.go
@@ -28,6 +28,9 @@ type ResolvedLocals struct {
 
 	// If set to true, the module will not be included in the output
 	Skip *bool
+
+	// Terraform version to use just for this project
+	TerraformVersion string
 }
 
 // parseHcl uses the HCL2 parser to parse the given string into an HCL file body.
@@ -82,6 +85,10 @@ func parseLocals(path string, terragruntOptions *options.TerragruntOptions, incl
 		parentLocals.AtlantisWorkflow = childLocals.AtlantisWorkflow
 	}
 
+	if childLocals.TerraformVersion != "" {
+		parentLocals.TerraformVersion = childLocals.TerraformVersion
+	}
+
 	if childLocals.AutoPlan != nil {
 		parentLocals.AutoPlan = childLocals.AutoPlan
 	}
@@ -112,6 +119,11 @@ func resolveLocals(localsAsCty cty.Value) ResolvedLocals {
 	workflowValue, ok := rawLocals["atlantis_workflow"]
 	if ok {
 		resolved.AtlantisWorkflow = workflowValue.AsString()
+	}
+
+	versionValue, ok := rawLocals["atlantis_terraform_version"]
+	if ok {
+		resolved.TerraformVersion = versionValue.AsString()
 	}
 
 	autoPlanValue, ok := rawLocals["atlantis_autoplan"]

--- a/test_examples/terraform_version/inherit_from_parent/terragrunt.hcl
+++ b/test_examples/terraform_version/inherit_from_parent/terragrunt.hcl
@@ -1,0 +1,11 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/terraform_version/override_parent/terragrunt.hcl
+++ b/test_examples/terraform_version/override_parent/terragrunt.hcl
@@ -1,0 +1,15 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+locals {
+  atlantis_terraform_version = "0.13.9001"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/terraform_version/terragrunt.hcl
+++ b/test_examples/terraform_version/terragrunt.hcl
@@ -1,0 +1,3 @@
+locals {
+  atlantis_terraform_version = "0.12.9001"
+}

--- a/test_examples/terraform_version/use_flag_default/terragrunt.hcl
+++ b/test_examples/terraform_version/use_flag_default/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+inputs = {
+  foo = "bar"
+}


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- Closes https://github.com/transcend-io/terragrunt-atlantis-config/issues/53

## Description

Allow specifying a terraform_version to use in the client-side atlantis.yaml file. You can also override this value on a module basis by using the `locals` value `atlantis_terraform_version`