### PR TITLE
Add flag to control repo automerge setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ terragrunt-atlantis-config generate --autoplan --output ./atlantis.yaml
 # enable auto plan
 terragrunt-atlantis-config generate --autoplan
 
+# enable auto merge
+terragrunt-atlantis-config generate --automerge
+
 # define the workflow
 terragrunt-atlantis-config generate --workflow web --output ./atlantis.yaml
 
@@ -112,6 +115,7 @@ One way to customize the behavior of this module is through CLI flag values pass
 | Flag Name                    | Description                                                                                                                                | Default Value     |
 |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|-------------------|
 | `--autoplan`                 | The default value for autoplan settings. Can be overriden by locals.                                                                       | false             |
+| `--automerge`                | Enables the automerge setting for a repo.                                                                                                  | false             |
 | `--ignore-parent-terragrunt` | Ignore parent Terragrunt configs (those which don't reference a terraform module).<br>In most cases, this should be set to `true`          | false             |
 | `--parallel`                 | Enables `plan`s and `apply`s to happen in parallel. Will typically be used with `--create-workspace`                                       | true              |
 | `--create-workspace`         | Use different auto-generated workspace for each project. Default is use default workspace for everything                                   | false             |

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -265,7 +265,7 @@ func main(cmd *cobra.Command, args []string) error {
 
 	config := AtlantisConfig{
 		Version:       3,
-		AutoMerge:     false,
+		AutoMerge:     autoMerge,
 		ParallelPlan:  parallel,
 		ParallelApply: parallel,
 	}
@@ -330,6 +330,7 @@ func main(cmd *cobra.Command, args []string) error {
 
 var gitRoot string
 var autoPlan bool
+var autoMerge bool
 var ignoreParentTerragrunt bool
 var parallel bool
 var createWorkspace bool
@@ -356,6 +357,7 @@ func init() {
 	}
 
 	generateCmd.PersistentFlags().BoolVar(&autoPlan, "autoplan", false, "Enable auto plan. Default is disabled")
+	generateCmd.PersistentFlags().BoolVar(&autoMerge, "automerge", false, "Enable auto merge. Default is disabled")
 	generateCmd.PersistentFlags().BoolVar(&ignoreParentTerragrunt, "ignore-parent-terragrunt", false, "Ignore parent terragrunt configs (those which don't reference a terraform module). Default is disabled")
 	generateCmd.PersistentFlags().BoolVar(&parallel, "parallel", true, "Enables plans and applys to happen in parallel. Default is enabled")
 	generateCmd.PersistentFlags().BoolVar(&createWorkspace, "create-workspace", false, "Use different workspace for each project. Default is use default workspace")

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -306,3 +306,11 @@ func TestPreservingOldWorkflows(t *testing.T) {
 		t.Errorf("Content did not match golden file.\n\nExpected Content: %s\n\nContent: %s", string(goldenContents), string(content))
 	}
 }
+
+func TestEnablingAutomerge(t *testing.T) {
+	runTest(t, filepath.Join("golden", "withAutomerge.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "basic_module"),
+		"--automerge",
+	})
+}

--- a/cmd/golden/withAutomerge.yaml
+++ b/cmd/golden/withAutomerge.yaml
@@ -1,0 +1,11 @@
+automerge: true
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: .
+version: 3


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- #97 

## Description

This Pull adds a boolean flag `--automerge` to control the setting in the `atlantis.yaml`

## Security Implications

- _[none]_

## System Availability

- _[should work on all]_
