### PR TITLE
Allow cascading dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,12 @@ build-all: clean
     -d=$(PATH_BUILD) \
     -build-ldflags "-X main.VERSION=$(VERSION)"
 
+.PHONY: gotestsum
+gotestsum:
+	mkdir -p cmd/test_artifacts
+	gotestsum
+	rm -rf cmd/test_artifacts
+
 .PHONY: test
 test:
 	mkdir -p cmd/test_artifacts

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.12.0
+VERSION=0.13.0
 PATH_BUILD=build/
 FILE_COMMAND=terragrunt-atlantis-config
 FILE_ARCH=darwin_amd64

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ jobs:
         id: atlantis_validator
         uses: transcend-io/terragrunt-atlantis-config-github-action@v0.0.3
         with:
-          version: v0.12.0
+          version: v0.13.0
           extra_args: '--autoplan --parallel=false
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ Alternative: Install a stable versions via Homebrew:
 brew install transcend-io/tap/terragrunt-atlantis-config
 ```
 
-This module officially supports golang versions v1.13, v1.14, and v1.15
+This module officially supports golang versions v1.13, v1.14, and v1.15, tested on CircleCI with each build
+This module also officially supports both Windows and Nix-based file formats, tested on CircleCI with each build
 
-Usage Examples:
+Usage Examples (see below sections for all options):
 
 ```bash
 # From the root of your repo
@@ -49,21 +50,6 @@ terragrunt-atlantis-config generate --root /some/path/to/your/repo/root
 
 # output to a file
 terragrunt-atlantis-config generate --autoplan --output ./atlantis.yaml
-
-# enable auto plan
-terragrunt-atlantis-config generate --autoplan
-
-# enable auto merge
-terragrunt-atlantis-config generate --automerge
-
-# define the workflow
-terragrunt-atlantis-config generate --workflow web --output ./atlantis.yaml
-
-# ignore parent terragrunt configs (those which don't reference a terraform module)
-terragrunt-atlantis-config generate --ignore-parent-terragrunt
-
-# Enable the project name creation
-terragrunt-atlantis-config generate --create-project-name
 ```
 
 Finally, check the log output (or your output file) for the YAML.
@@ -95,10 +81,10 @@ In your `atlantis.yaml` file, you will end up seeing output like:
 - autoplan:
     enabled: false
     when_modified:
-    - '*.hcl'
-    - '*.tf*'
-    - some_extra_dep
-    - ../../.gitignore
+      - "*.hcl"
+      - "*.tf*"
+      - some_extra_dep
+      - ../../.gitignore
   dir: example-setup/extra_dependency
 ```
 
@@ -112,26 +98,27 @@ If you specify `extra_atlantis_dependencies` in the parent Terragrunt module, th
 
 One way to customize the behavior of this module is through CLI flag values passed in at runtime. These settings will apply to all modules.
 
-| Flag Name                    | Description                                                                                                                                | Default Value     |
-|------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|-------------------|
-| `--autoplan`                 | The default value for autoplan settings. Can be overriden by locals.                                                                       | false             |
-| `--automerge`                | Enables the automerge setting for a repo.                                                                                                  | false             |
-| `--ignore-parent-terragrunt` | Ignore parent Terragrunt configs (those which don't reference a terraform module).<br>In most cases, this should be set to `true`          | false             |
-| `--parallel`                 | Enables `plan`s and `apply`s to happen in parallel. Will typically be used with `--create-workspace`                                       | true              |
-| `--create-workspace`         | Use different auto-generated workspace for each project. Default is use default workspace for everything                                   | false             |
-| `--create-project-name`      | Add different auto-generated name for each project                                                                                         | false             |
-| `--preserve-workflows`       | Preserves workflows from old output files. Useful if you want to define your workflow definitions on the client side                       | true              |
-| `--workflow`                 | Name of the workflow to be customized in the atlantis server. If empty, will be left out of output                                         | ""                |
-| `--output`                   | Path of the file where configuration will be generated. Typically, you want a file named "atlantis.yaml". Default is to write to `stdout`. | ""                |
-| `--root`                     | Path to the root directory of the git repo you want to build config for.                                                                   | current directory |
-| `--terraform-version`        | Default terraform version to specify for all modules. Can be overriden by locals                                                           | ""                |
+| Flag Name                    | Description                                                                                                                                                                     | Default Value     |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `--autoplan`                 | The default value for autoplan settings. Can be overriden by locals.                                                                                                            | false             |
+| `--automerge`                | Enables the automerge setting for a repo.                                                                                                                                       | false             |
+| `--cascade-dependencies`     | When true, dependencies will cascade, meaning that a module will be declared to depend not only on its dependencies, but all dependencies of its dependencies all the way down. | true              |
+| `--ignore-parent-terragrunt` | Ignore parent Terragrunt configs (those which don't reference a terraform module).<br>In most cases, this should be set to `true`                                               | false             |
+| `--parallel`                 | Enables `plan`s and `apply`s to happen in parallel. Will typically be used with `--create-workspace`                                                                            | true              |
+| `--create-workspace`         | Use different auto-generated workspace for each project. Default is use default workspace for everything                                                                        | false             |
+| `--create-project-name`      | Add different auto-generated name for each project                                                                                                                              | false             |
+| `--preserve-workflows`       | Preserves workflows from old output files. Useful if you want to define your workflow definitions on the client side                                                            | true              |
+| `--workflow`                 | Name of the workflow to be customized in the atlantis server. If empty, will be left out of output                                                                              | ""                |
+| `--output`                   | Path of the file where configuration will be generated. Typically, you want a file named "atlantis.yaml". Default is to write to `stdout`.                                      | ""                |
+| `--root`                     | Path to the root directory of the git repo you want to build config for.                                                                                                        | current directory |
+| `--terraform-version`        | Default terraform version to specify for all modules. Can be overriden by locals                                                                                                | ""                |
 
 ## All Locals
 
 Another way to customize the output is to use `locals` values in your terragrunt modules. These can be set in either the parent or child terragrunt modules, and the settings will only affect the current module (or all child modules for parent locals).
 
 | Locals Name                   | Description                                                                                                                                                    | type         |
-|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
 | `atlantis_workflow`           | The custom atlantis workflow name to use for a module                                                                                                          | string       |
 | `atlantis_terraform_version`  | Allows overriding the `--terraform-version` flag for a single module                                                                                           | string       |
 | `atlantis_autoplan`           | Allows overriding the `--autoplan` flag for a single module                                                                                                    | bool         |

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -179,6 +179,7 @@ func getDependencies(path string, terragruntOptions *options.TerragruntOptions) 
 					return nil, err
 				}
 			}
+			childDepAbsPath = filepath.ToSlash(childDepAbsPath)
 
 			// Ensure we are not adding a duplicate dependency
 			alreadyExists := false

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -18,6 +18,8 @@ func resetDefaultFlags() error {
 
 	gitRoot = pwd
 	autoPlan = false
+	autoMerge = false
+	cascadeDependencies = true
 	ignoreParentTerragrunt = false
 	parallel = true
 	createWorkspace = false
@@ -50,7 +52,7 @@ func runTest(t *testing.T, goldenFile string, args []string) {
 
 	content, err := RunWithFlags(filename, allArgs)
 	if err != nil {
-		t.Error("Failed to read file")
+		t.Error(err)
 		return
 	}
 
@@ -312,5 +314,21 @@ func TestEnablingAutomerge(t *testing.T) {
 		"--root",
 		filepath.Join("..", "test_examples", "basic_module"),
 		"--automerge",
+	})
+}
+
+func TestChainedDependencies(t *testing.T) {
+	runTest(t, filepath.Join("golden", "chained_dependency.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "chained_dependencies"),
+		"--cascade-dependencies",
+	})
+}
+
+func TestChainedDependenciesHiddenBehindFlag(t *testing.T) {
+	runTest(t, filepath.Join("golden", "chained_dependency_no_flag.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "chained_dependencies"),
+		"--cascade-dependencies=false",
 	})
 }

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -67,7 +67,7 @@ func runTest(t *testing.T, goldenFile string, args []string) {
 	}
 
 	if string(content) != string(goldenContents) {
-		t.Errorf("Content did not match golden file.\n\nExpected Content: %s\n\nContent: %s", string(goldenContents), string(content))
+		t.Errorf("Content did not match golden file.\n\nExpected (Golden file) Contents: \n%s\n\nGenerated Content: \n%s", string(goldenContents), string(content))
 	}
 }
 

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -10,12 +10,16 @@ import (
 )
 
 // Resets all flag values to their defaults in between tests
-func resetDefaultFlags() error {
+func resetForRun() error {
 	pwd, err := os.Getwd()
 	if err != nil {
 		return err
 	}
 
+	// reset caches
+	getDependenciesCache = make(map[string]getDependenciesOutput)
+
+	// reset flags
 	gitRoot = pwd
 	autoPlan = false
 	autoMerge = false
@@ -34,7 +38,7 @@ func resetDefaultFlags() error {
 
 // Runs a test, asserting the output produced matches a golden file
 func runTest(t *testing.T, goldenFile string, args []string) {
-	err := resetDefaultFlags()
+	err := resetForRun()
 	if err != nil {
 		t.Error("Failed to reset default flags")
 		return
@@ -263,7 +267,7 @@ func TestTerraformVersionConfig(t *testing.T) {
 }
 
 func TestPreservingOldWorkflows(t *testing.T) {
-	err := resetDefaultFlags()
+	err := resetForRun()
 	if err != nil {
 		t.Error("Failed to reset default flags")
 		return

--- a/cmd/golden/chained_dependency.yaml
+++ b/cmd/golden/chained_dependency.yaml
@@ -22,5 +22,13 @@ projects:
     - '*.tf*'
     - ../depender/terragrunt.hcl
     - ../dependency/terragrunt.hcl
+    - nested/terragrunt.hcl
   dir: depender_on_depender
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../dependency/terragrunt.hcl
+  dir: depender_on_depender/nested
 version: 3

--- a/cmd/golden/chained_dependency.yaml
+++ b/cmd/golden/chained_dependency.yaml
@@ -1,0 +1,26 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: dependency
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../dependency/terragrunt.hcl
+  dir: depender
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../depender/terragrunt.hcl
+    - ../dependency/terragrunt.hcl
+  dir: depender_on_depender
+version: 3

--- a/cmd/golden/chained_dependency_no_flag.yaml
+++ b/cmd/golden/chained_dependency_no_flag.yaml
@@ -21,5 +21,13 @@ projects:
     - '*.hcl'
     - '*.tf*'
     - ../depender/terragrunt.hcl
+    - nested/terragrunt.hcl
   dir: depender_on_depender
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../dependency/terragrunt.hcl
+  dir: depender_on_depender/nested
 version: 3

--- a/cmd/golden/chained_dependency_no_flag.yaml
+++ b/cmd/golden/chained_dependency_no_flag.yaml
@@ -1,0 +1,25 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: dependency
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../dependency/terragrunt.hcl
+  dir: depender
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../depender/terragrunt.hcl
+  dir: depender_on_depender
+version: 3

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import "github.com/transcend-io/terragrunt-atlantis-config/cmd"
 // This variable is set at build time using -ldflags parameters.
 // But we still set a default here for those using plain `go get` downloads
 // For more info, see: http://stackoverflow.com/a/11355611/483528
-var VERSION string = "0.12.0"
+var VERSION string = "0.13.0"
 
 func main() {
 	cmd.Execute(VERSION)

--- a/test_examples/chained_dependencies/dependency/terragrunt.hcl
+++ b/test_examples/chained_dependencies/dependency/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/chained_dependencies/depender/terragrunt.hcl
+++ b/test_examples/chained_dependencies/depender/terragrunt.hcl
@@ -1,0 +1,11 @@
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+dependency "some_dep" {
+  config_path = "../dependency"
+}
+
+inputs = {
+  foo = dependency.some_dep.outputs.some_output
+}

--- a/test_examples/chained_dependencies/depender_on_depender/nested/terragrunt.hcl
+++ b/test_examples/chained_dependencies/depender_on_depender/nested/terragrunt.hcl
@@ -3,11 +3,7 @@ terraform {
 }
 
 dependency "some_dep" {
-  config_path = "../depender"
-}
-
-dependency "nested" {
-  config_path = "./nested"
+  config_path = "../../dependency"
 }
 
 inputs = {

--- a/test_examples/chained_dependencies/depender_on_depender/terragrunt.hcl
+++ b/test_examples/chained_dependencies/depender_on_depender/terragrunt.hcl
@@ -1,0 +1,11 @@
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+dependency "some_dep" {
+  config_path = "../depender"
+}
+
+inputs = {
+  foo = dependency.some_dep.outputs.some_output
+}


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- Closes https://github.com/transcend-io/terragrunt-atlantis-config/issues/82

## Description

Before this change, if we had the dependency tree of modules

A -> B -> C

And module C is updated, only module B knows that C was updated, but we really want module A to know that C was updated as well.

This PR will also state that module A depends on module C.

It can be optionally controlled by the flag `--cascade-dependencies`, which defaults to true.