### PR TITLE
Allow ignoring dependency blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ One way to customize the behavior of this module is through CLI flag values pass
 | `--output`                   | Path of the file where configuration will be generated. Typically, you want a file named "atlantis.yaml". Default is to write to `stdout`.                                      | ""                |
 | `--root`                     | Path to the root directory of the git repo you want to build config for.                                                                                                        | current directory |
 | `--terraform-version`        | Default terraform version to specify for all modules. Can be overriden by locals                                                                                                | ""                |
+| `--ignore-dependency-blocks` | When true, dependencies found in `dependency` and `dependencies` blocks will be ignored                                                                                         | false             |
 
 ## All Locals
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -100,7 +100,7 @@ func getDependencies(path string, terragruntOptions *options.TerragruntOptions) 
 	}
 
 	// Get deps from `dependencies` and `dependency` blocks
-	if parsedConfig.Dependencies != nil {
+	if parsedConfig.Dependencies != nil && !ignoreDependencyBlocks {
 		for _, parsedPaths := range parsedConfig.Dependencies.Paths {
 			dependencies = append(dependencies, filepath.Join(parsedPaths, "terragrunt.hcl"))
 		}
@@ -400,6 +400,7 @@ var gitRoot string
 var autoPlan bool
 var autoMerge bool
 var ignoreParentTerragrunt bool
+var ignoreDependencyBlocks bool
 var parallel bool
 var createWorkspace bool
 var createProjectName bool
@@ -428,6 +429,7 @@ func init() {
 	generateCmd.PersistentFlags().BoolVar(&autoPlan, "autoplan", false, "Enable auto plan. Default is disabled")
 	generateCmd.PersistentFlags().BoolVar(&autoMerge, "automerge", false, "Enable auto merge. Default is disabled")
 	generateCmd.PersistentFlags().BoolVar(&ignoreParentTerragrunt, "ignore-parent-terragrunt", true, "Ignore parent terragrunt configs (those which don't reference a terraform module). Default is enabled")
+	generateCmd.PersistentFlags().BoolVar(&ignoreDependencyBlocks, "ignore-dependency-blocks", false, "When true, dependencies found in `dependency` blocks will be ignored")
 	generateCmd.PersistentFlags().BoolVar(&parallel, "parallel", true, "Enables plans and applys to happen in parallel. Default is enabled")
 	generateCmd.PersistentFlags().BoolVar(&createWorkspace, "create-workspace", false, "Use different workspace for each project. Default is use default workspace")
 	generateCmd.PersistentFlags().BoolVar(&createProjectName, "create-project-name", false, "Add different name for each project. Default is false")

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -25,6 +25,7 @@ func resetForRun() error {
 	autoMerge = false
 	cascadeDependencies = true
 	ignoreParentTerragrunt = true
+	ignoreDependencyBlocks = false
 	parallel = true
 	createWorkspace = false
 	createProjectName = false
@@ -163,6 +164,14 @@ func TestTerragruntDependencies(t *testing.T) {
 	runTest(t, filepath.Join("golden", "terragrunt_dependency.yaml"), []string{
 		"--root",
 		filepath.Join("..", "test_examples", "terragrunt_dependency"),
+	})
+}
+
+func TestIgnoringTerragruntDependencies(t *testing.T) {
+	runTest(t, filepath.Join("golden", "terragrunt_dependency_ignored.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "terragrunt_dependency"),
+		"--ignore-dependency-blocks",
 	})
 }
 

--- a/cmd/golden/terragrunt_dependency_ignored.yaml
+++ b/cmd/golden/terragrunt_dependency_ignored.yaml
@@ -1,0 +1,17 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: dependency
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: depender
+version: 3


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- Closes https://github.com/transcend-io/terragrunt-atlantis-config/issues/101

## Description

Adds a `--ignore-dependency-blocks` flag that allows ignoring `dependency` and `dependencies` blocks