### PR TITLE
Add support for changing the `apply_requirements` field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.0.1
+VERSION=1.1.0
 PATH_BUILD=build/
 FILE_COMMAND=terragrunt-atlantis-config
 FILE_ARCH=darwin_amd64

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Then, make sure `terragrunt-atlantis-config` is present on your Atlantis server.
 
 ```go
 variable terragrunt_atlantis_config_version {
-  default = "1.0.1"
+  default = "1.1.0"
 }
 
 build {
@@ -117,6 +117,7 @@ One way to customize the behavior of this module is through CLI flag values pass
 | `--create-project-name`      | Add different auto-generated name for each project                                                                                                                              | false             |
 | `--preserve-workflows`       | Preserves workflows from old output files. Useful if you want to define your workflow definitions on the client side                                                            | true              |
 | `--workflow`                 | Name of the workflow to be customized in the atlantis server. If empty, will be left out of output                                                                              | ""                |
+| `--approval-requirements`    | Requirements that must be satisfied before `atlantis apply` can be run. Currently the only supported requirements are `approved` and `mergeable`. Can be overridden by locals   | []                |
 | `--output`                   | Path of the file where configuration will be generated. Typically, you want a file named "atlantis.yaml". Default is to write to `stdout`.                                      | ""                |
 | `--root`                     | Path to the root directory of the git repo you want to build config for.                                                                                                        | current directory |
 | `--terraform-version`        | Default terraform version to specify for all modules. Can be overriden by locals                                                                                                | ""                |
@@ -129,6 +130,7 @@ Another way to customize the output is to use `locals` values in your terragrunt
 | Locals Name                   | Description                                                                                                                                                    | type         |
 | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
 | `atlantis_workflow`           | The custom atlantis workflow name to use for a module                                                                                                          | string       |
+| `atlantis_apply_requirements` | The custom `apply_requirements` array to use for a module                                                                                                      | list(string) |
 | `atlantis_terraform_version`  | Allows overriding the `--terraform-version` flag for a single module                                                                                           | string       |
 | `atlantis_autoplan`           | Allows overriding the `--autoplan` flag for a single module                                                                                                    | bool         |
 | `atlantis_skip`               | If true on a child module, that module will not appear in the output.<br>If true on a parent module, none of that parent's children will appear in the output. | bool         |
@@ -159,7 +161,7 @@ You can install this tool locally to checkout what kinds of config it will gener
 Recommended: Install any version via go get:
 
 ```bash
-cd && GO111MODULE=on go get github.com/transcend-io/terragrunt-atlantis-config@v1.0.1 && cd -
+cd && GO111MODULE=on go get github.com/transcend-io/terragrunt-atlantis-config@v1.1.0 && cd -
 ```
 
 This module officially supports golang versions v1.13, v1.14, and v1.15, tested on CircleCI with each build

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -49,6 +49,8 @@ type AtlantisProject struct {
 
 	// The terraform version to use for this project
 	TerraformVersion string `json:"terraform_version,omitempty"`
+
+	ApplyRequirements []string `json:"apply_requirements,omitempty"`
 }
 
 // Autoplan settings for which plans affect other plans

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -257,6 +257,11 @@ func createProject(sourcePath string) (*AtlantisProject, error) {
 		workflow = locals.AtlantisWorkflow
 	}
 
+	applyRequirements := defaultApplyRequirements
+	if locals.ApplyRequirements != nil && len(locals.ApplyRequirements) > 0 {
+		applyRequirements = locals.ApplyRequirements
+	}
+
 	resolvedAutoPlan := autoPlan
 	if locals.AutoPlan != nil {
 		resolvedAutoPlan = *locals.AutoPlan
@@ -268,9 +273,10 @@ func createProject(sourcePath string) (*AtlantisProject, error) {
 	}
 
 	project := &AtlantisProject{
-		Dir:              filepath.ToSlash(relativeSourceDir),
-		Workflow:         workflow,
-		TerraformVersion: terraformVersion,
+		Dir:               filepath.ToSlash(relativeSourceDir),
+		Workflow:          workflow,
+		TerraformVersion:  terraformVersion,
+		ApplyRequirements: applyRequirements,
 		Autoplan: AutoplanConfig{
 			Enabled:      resolvedAutoPlan,
 			WhenModified: relativeDependencies,
@@ -409,6 +415,7 @@ var defaultWorkflow string
 var outputPath string
 var preserveWorkflows bool
 var cascadeDependencies bool
+var defaultApplyRequirements []string
 
 // generateCmd represents the generate command
 var generateCmd = &cobra.Command{
@@ -436,6 +443,7 @@ func init() {
 	generateCmd.PersistentFlags().BoolVar(&preserveWorkflows, "preserve-workflows", true, "Preserves workflows from old output files. Default is true")
 	generateCmd.PersistentFlags().BoolVar(&cascadeDependencies, "cascade-dependencies", true, "When true, dependencies will cascade, meaning that a module will be declared to depend not only on its dependencies, but all dependencies of its dependencies all the way down. Default is true")
 	generateCmd.PersistentFlags().StringVar(&defaultWorkflow, "workflow", "", "Name of the workflow to be customized in the atlantis server. Default is to not set")
+	generateCmd.PersistentFlags().StringSliceVar(&defaultApplyRequirements, "apply-requirements", []string{}, "Requirements that must be satisfied before `atlantis apply` can be run. Currently the only supported requirements are `approved` and `mergeable`. Can be overridden by locals")
 	generateCmd.PersistentFlags().StringVar(&outputPath, "output", "", "Path of the file where configuration will be generated. Default is not to write to file")
 	generateCmd.PersistentFlags().StringVar(&gitRoot, "root", pwd, "Path to the root directory of the git repo you want to build config for. Default is current dir")
 	generateCmd.PersistentFlags().StringVar(&defaultTerraformVersion, "terraform-version", "", "Default terraform version to specify for all modules. Can be overriden by locals")

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -33,6 +33,7 @@ func resetForRun() error {
 	defaultWorkflow = ""
 	outputPath = ""
 	defaultTerraformVersion = ""
+	defaultApplyRequirements = []string{}
 
 	return nil
 }
@@ -333,5 +334,20 @@ func TestChainedDependenciesHiddenBehindFlag(t *testing.T) {
 		"--root",
 		filepath.Join("..", "test_examples", "chained_dependencies"),
 		"--cascade-dependencies=false",
+	})
+}
+
+func TestApplyRequirementsLocals(t *testing.T) {
+	runTest(t, filepath.Join("golden", "apply_overrides.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "apply_requirements_overrides"),
+	})
+}
+
+func TestApplyRequirementsFlag(t *testing.T) {
+	runTest(t, filepath.Join("golden", "apply_overrides_flag.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "basic_module"),
+		"--apply-requirements=approved,mergeable",
 	})
 }

--- a/cmd/golden/apply_overrides.yaml
+++ b/cmd/golden/apply_overrides.yaml
@@ -1,0 +1,21 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- apply_requirements:
+  - approved
+  autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: child_that_does_not_override
+- apply_requirements:
+  - mergeable
+  autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: child_that_overrides
+version: 3

--- a/cmd/golden/apply_overrides_flag.yaml
+++ b/cmd/golden/apply_overrides_flag.yaml
@@ -1,0 +1,14 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- apply_requirements:
+  - approved
+  - mergeable
+  autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: .
+version: 3

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import "github.com/transcend-io/terragrunt-atlantis-config/cmd"
 // This variable is set at build time using -ldflags parameters.
 // But we still set a default here for those using plain `go get` downloads
 // For more info, see: http://stackoverflow.com/a/11355611/483528
-var VERSION string = "1.0.1"
+var VERSION string = "1.1.0"
 
 func main() {
 	cmd.Execute(VERSION)

--- a/test_examples/apply_requirements_overrides/child_that_does_not_override/terragrunt.hcl
+++ b/test_examples/apply_requirements_overrides/child_that_does_not_override/terragrunt.hcl
@@ -1,0 +1,11 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/apply_requirements_overrides/child_that_overrides/terragrunt.hcl
+++ b/test_examples/apply_requirements_overrides/child_that_overrides/terragrunt.hcl
@@ -1,0 +1,15 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+locals {
+  atlantis_apply_requirements = ["mergeable"]
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/apply_requirements_overrides/terragrunt.hcl
+++ b/test_examples/apply_requirements_overrides/terragrunt.hcl
@@ -1,0 +1,3 @@
+locals {
+  atlantis_apply_requirements = ["approved"]
+}


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- Closes https://github.com/transcend-io/terragrunt-atlantis-config/issues/108

## Description

Adds support for using `apply_requirements` in the terragrunt config.

These can be set in three ways:

1. Using a flag

You can use `--apply-requirements` in your `generate` command to set defaults that will apply to all modules

2. Using a local in the parent config

You can set the local `atlantis_apply_requirements` in your parent config to override all modules that inherit from that parent. This config is **not** additive to the `--apply-requirements` flag, but overrides the array entirely

3. Using a local in the child config

You can set the local `atlantis_apply_requirements` in your child config to override the setting for a single module. This config is **not** additive to the `--apply-requirements` flag or the local in the parent config, but overrides the array entirely
