### PR TITLE
Fix issue with parsing for a cascading dependencies case, Fix Duplicated dependencies, Handle Relative/Absolute Paths more gracefully

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -143,7 +143,12 @@ func getDependencies(path string, terragruntOptions *options.TerragruntOptions) 
 	nonEmptyDeps := []string{}
 	for _, dep := range dependencies {
 		if dep != "" {
-			nonEmptyDeps = append(nonEmptyDeps, dep)
+			childDepAbsPath := dep
+			if !filepath.IsAbs(childDepAbsPath) {
+				childDepAbsPath = makePathAbsolute(dep, path)
+			}
+			childDepAbsPath = filepath.ToSlash(childDepAbsPath)
+			nonEmptyDeps = append(nonEmptyDeps, childDepAbsPath)
 		}
 	}
 
@@ -157,12 +162,9 @@ func getDependencies(path string, terragruntOptions *options.TerragruntOptions) 
 			continue
 		}
 
-		// To find the path to the dependency, we join three things:
-		// 1. The path to the current module, `path`
-		// 2. `..`, because `path` includes the `terragrunt.hcl` file extension, while the `dep` path is relative to the folder that file is in
-		// 3. the relative path from the current module to the dependency, `dep`
-		depPath := filepath.Join(path, "..", dep)
-		childDeps, err := getDependencies(depPath, terragruntOptions)
+		depPath := dep
+		terrOpts, err := options.NewTerragruntOptions(depPath)
+		childDeps, err := getDependencies(depPath, terrOpts)
 		if err != nil {
 			continue
 		}
@@ -237,11 +239,15 @@ func createProject(sourcePath string) (*AtlantisProject, error) {
 
 	// Add other dependencies based on their relative paths. We always want to output with Unix path separators
 	for _, dependencyPath := range dependencies {
-		absolutePath := makePathAbsolute(dependencyPath, sourcePath)
+		absolutePath := dependencyPath
+		if !filepath.IsAbs(absolutePath) {
+			absolutePath = makePathAbsolute(dependencyPath, sourcePath)
+		}
 		relativePath, err := filepath.Rel(absoluteSourceDir, absolutePath)
 		if err != nil {
 			return nil, err
 		}
+
 		relativeDependencies = append(relativeDependencies, filepath.ToSlash(relativePath))
 	}
 

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -244,6 +244,14 @@ func TestInfrastructureLive(t *testing.T) {
 	})
 }
 
+func TestInfrastructureMutliAccountsVPCRoute53TGWCascading(t *testing.T) {
+	runTest(t, filepath.Join("golden", "multi_accounts_vpc_route53_tgw.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "multi_accounts_vpc_route53_tgw"),
+		"--cascade-dependencies",
+	})
+}
+
 func TestAutoPlan(t *testing.T) {
 	runTest(t, filepath.Join("golden", "autoplan.yaml"), []string{
 		"--root",

--- a/cmd/golden/multi_accounts_vpc_route53_tgw.yaml
+++ b/cmd/golden/multi_accounts_vpc_route53_tgw.yaml
@@ -1,0 +1,26 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: network-account/eu-west-1/network/transit-gateway
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../env-a/network/vpc/terragrunt.hcl
+    - ../../../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
+  dir: prod/eu-west-1/_global/route53/test-zone
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
+  dir: prod/eu-west-1/env-a/network/vpc
+version: 3

--- a/test_examples/multi_accounts_vpc_route53_tgw/network-account/eu-west-1/network/env.hcl
+++ b/test_examples/multi_accounts_vpc_route53_tgw/network-account/eu-west-1/network/env.hcl
@@ -1,0 +1,3 @@
+locals {
+  env                  = "network"
+}

--- a/test_examples/multi_accounts_vpc_route53_tgw/network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
+++ b/test_examples/multi_accounts_vpc_route53_tgw/network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
@@ -1,0 +1,21 @@
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+terraform {
+  source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//tgw?ref=v0.3.0"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+locals {
+  # Automatically load environment-level variables
+  env_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+  # Extract out common variables for reuse
+  env_name = local.env_vars.locals.env
+}
+
+inputs = {
+  name                      = "tgw-${local.env_name}"
+}

--- a/test_examples/multi_accounts_vpc_route53_tgw/prod/eu-west-1/_global/env.hcl
+++ b/test_examples/multi_accounts_vpc_route53_tgw/prod/eu-west-1/_global/env.hcl
@@ -1,0 +1,3 @@
+locals {
+  env                  = "global-region"
+}

--- a/test_examples/multi_accounts_vpc_route53_tgw/prod/eu-west-1/_global/route53/test-zone/terragrunt.hcl
+++ b/test_examples/multi_accounts_vpc_route53_tgw/prod/eu-west-1/_global/route53/test-zone/terragrunt.hcl
@@ -1,0 +1,28 @@
+locals {
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+
+  # Extract out common variables for reuse
+  env = local.environment_vars.locals.env
+}
+
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+terraform {
+  source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//zone?ref=v0.3.0"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+dependency "vpc" {
+  config_path = "../../../env-a/network/vpc/"
+}
+
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+inputs = {
+  name           = "test_zone_${local.env}"
+}
+

--- a/test_examples/multi_accounts_vpc_route53_tgw/prod/eu-west-1/env-a/env.hcl
+++ b/test_examples/multi_accounts_vpc_route53_tgw/prod/eu-west-1/env-a/env.hcl
@@ -1,0 +1,4 @@
+locals {
+  env                     = "env-a"
+  stack_name              = "Environment-a"
+}

--- a/test_examples/multi_accounts_vpc_route53_tgw/prod/eu-west-1/env-a/network/vpc/terragrunt.hcl
+++ b/test_examples/multi_accounts_vpc_route53_tgw/prod/eu-west-1/env-a/network/vpc/terragrunt.hcl
@@ -1,0 +1,26 @@
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+terraform {
+  source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//vpc?ref=v0.3.0"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+locals {
+  # Automatically load environment-level variables
+  env_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+  # Extract out common variables for reuse
+  stack_name = local.env_vars.locals.stack_name
+}
+
+dependency "tgw" {
+  config_path = "../../../../../network-account/eu-west-1/network/transit-gateway/"
+}
+
+inputs = {
+  name                      = local.stack_name
+  transit_gateway_id        = dependency.tgw.outputs.this_ec2_transit_gateway_id
+}

--- a/test_examples/multi_accounts_vpc_route53_tgw/terragrunt.hcl
+++ b/test_examples/multi_accounts_vpc_route53_tgw/terragrunt.hcl
@@ -1,0 +1,18 @@
+locals {
+
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# GLOBAL PARAMETERS
+# These variables apply to all configurations in this subfolder. These are automatically merged into the child
+# `terragrunt.hcl` config via the include block.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# Configure root level variables that all resources can inherit. This is especially helpful with multi-account configs
+# where terraform_remote_state data sources are placed directly into the modules.
+inputs = merge(
+local.environment_vars.locals,
+)


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- _[none]_

## Description

- Improvement: In order to fix the issue with cascading dependencies this adds extra checks to handle both the case that a dependency uses an absolute path or a relative one.
- Improvement: Also converts relative dependencies to absolute to avoid duplicates and re-converts the dependencies to a relative before the configuration file is generated.

- Fix issue with parsing for a cascading dependencies case
Creates new terragrunt options with the dependency path in order to be able to parse successfully the cascading dependencies.


## Security Implications

- _[none]_

## System Availability

- _[none]_
