### PR TITLE
bump version to 1.1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,23 +75,6 @@ jobs:
           path: /tmp/test-results
 
 
-  publish:
-    docker:
-      - image: circleci/golang:1.14
-
-    working_directory: /go/src/github.com/transcend-io/terragrunt-atlantis-config
-    steps:
-      - checkout
-      - restore_cache: # restores saved cache if no changes are detected since last run
-          keys:
-            - go-mod-v6-{{ checksum "go.sum" }}-1.14
-      - aws-cli/install
-      - assume-role/assume-role:
-          account-id: $PROD_ACCOUNT_ID
-          role-name: CI-Robots-Role-Prod
-      - run: go get github.com/laher/goxc
-      - run: make ci_publish
-
 workflows:
   version: 2
   main_workflow:
@@ -105,13 +88,3 @@ workflows:
           matrix:
             parameters:
               golang-version: ["1.15", "1.14", "1.13"]
-
-      - publish:
-          context: release-ctx
-          requires:
-            - build_and_test
-            - test_on_windows
-          filters:
-            branches:
-              only:
-                - master

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.1.0
+VERSION=1.1.1
 PATH_BUILD=build/
 FILE_COMMAND=terragrunt-atlantis-config
 FILE_ARCH=darwin_amd64
@@ -52,19 +52,7 @@ sign:  build-all
 	rm -f $(PATH_BUILD)${VERSION}/SHA256SUMS
 	shasum -a256 $(PATH_BUILD)${VERSION}/* > $(PATH_BUILD)${VERSION}/SHA256SUMS
 
-.PHONY: shasum
-shasum:  build
-	shasum -a256 $(PATH_BUILD)$(VERSION)/$(FILE_COMMAND)_$(VERSION)_$(FILE_ARCH).zip
-
 .PHONY: install
 install:
 	install -d -m 755 '$(HOME)/bin/'
 	install $(PATH_BUILD)$(FILE_COMMAND)/$(VERSION)/$(FILE_COMMAND)_$(VERSION)_$(FILE_ARCH) '$(HOME)/bin/$(FILE_COMMAND)'
-
-.PHONY: publish
-publish: build
-	AWS_PROFILE=$(PROFILE) aws s3 sync $(PATH_BUILD)/$(VERSION) s3://$(S3_BUCKET_NAME)/$(FILE_COMMAND)/$(VERSION)
-
-.PHONY: ci_publish
-ci_publish: build
-	aws s3 sync $(PATH_BUILD)$(VERSION) s3://$(S3_BUCKET_NAME)/$(FILE_COMMAND)/$(VERSION)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Then, make sure `terragrunt-atlantis-config` is present on your Atlantis server.
 
 ```go
 variable terragrunt_atlantis_config_version {
-  default = "1.1.0"
+  default = "1.1.1"
 }
 
 build {
@@ -161,7 +161,7 @@ You can install this tool locally to checkout what kinds of config it will gener
 Recommended: Install any version via go get:
 
 ```bash
-cd && GO111MODULE=on go get github.com/transcend-io/terragrunt-atlantis-config@v1.1.0 && cd -
+cd && GO111MODULE=on go get github.com/transcend-io/terragrunt-atlantis-config@v1.1.1 && cd -
 ```
 
 This module officially supports golang versions v1.13, v1.14, and v1.15, tested on CircleCI with each build

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import "github.com/transcend-io/terragrunt-atlantis-config/cmd"
 // This variable is set at build time using -ldflags parameters.
 // But we still set a default here for those using plain `go get` downloads
 // For more info, see: http://stackoverflow.com/a/11355611/483528
-var VERSION string = "1.1.0"
+var VERSION string = "1.1.1"
 
 func main() {
 	cmd.Execute(VERSION)


### PR DESCRIPTION
also removes a deprecated CI job