### PR TITLE
feat: Add filter flag to allow generating configs for subset of folders

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -321,7 +321,10 @@ func getAllTerragruntFiles() ([]string, error) {
 	// to root and just ignore the ConfigFiles
 	workingPath := gitRoot
 	if filterPath != "" {
-		workingPath = filterPath
+		workingPath, err = filepath.Abs(filterPath)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	paths, err := config.FindConfigFilesInPath(workingPath, options)

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -316,7 +316,15 @@ func getAllTerragruntFiles() ([]string, error) {
 		return nil, err
 	}
 
-	paths, err := config.FindConfigFilesInPath(gitRoot, options)
+	// If filterPath is provided, override workingPath instead of gitRoot
+	// We do this here because we want to keep the relative path structure of Terragrunt files
+	// to root and just ignore the ConfigFiles
+	workingPath := gitRoot
+	if filterPath != "" {
+		workingPath = filterPath
+	}
+
+	paths, err := config.FindConfigFilesInPath(workingPath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -418,6 +426,7 @@ var createWorkspace bool
 var createProjectName bool
 var defaultTerraformVersion string
 var defaultWorkflow string
+var filterPath string
 var outputPath string
 var preserveWorkflows bool
 var cascadeDependencies bool
@@ -451,6 +460,7 @@ func init() {
 	generateCmd.PersistentFlags().StringVar(&defaultWorkflow, "workflow", "", "Name of the workflow to be customized in the atlantis server. Default is to not set")
 	generateCmd.PersistentFlags().StringSliceVar(&defaultApplyRequirements, "apply-requirements", []string{}, "Requirements that must be satisfied before `atlantis apply` can be run. Currently the only supported requirements are `approved` and `mergeable`. Can be overridden by locals")
 	generateCmd.PersistentFlags().StringVar(&outputPath, "output", "", "Path of the file where configuration will be generated. Default is not to write to file")
+	generateCmd.PersistentFlags().StringVar(&filterPath, "filter", "", "Path to the directory you want scope down the config for. Default is all files in root")
 	generateCmd.PersistentFlags().StringVar(&gitRoot, "root", pwd, "Path to the root directory of the git repo you want to build config for. Default is current dir")
 	generateCmd.PersistentFlags().StringVar(&defaultTerraformVersion, "terraform-version", "", "Default terraform version to specify for all modules. Can be overriden by locals")
 }

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -31,6 +31,7 @@ func resetForRun() error {
 	createProjectName = false
 	preserveWorkflows = true
 	defaultWorkflow = ""
+	filterPath = ""
 	outputPath = ""
 	defaultTerraformVersion = ""
 	defaultApplyRequirements = []string{}
@@ -366,5 +367,23 @@ func TestApplyRequirementsFlag(t *testing.T) {
 		"--root",
 		filepath.Join("..", "test_examples", "basic_module"),
 		"--apply-requirements=approved,mergeable",
+	})
+}
+
+func TestFilterFlagWithInfraLiveProd(t *testing.T) {
+	runTest(t, filepath.Join("golden", "filterInfraLiveProd.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "terragrunt-infrastructure-live-example"),
+		"--filter",
+		filepath.Join("..", "test_examples", "terragrunt-infrastructure-live-example", "prod"),
+	})
+}
+
+func TestFilterFlagWithInfraLiveNonProd(t *testing.T) {
+	runTest(t, filepath.Join("golden", "filterInfraLiveNonProd.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "terragrunt-infrastructure-live-example"),
+		"--filter",
+		filepath.Join("..", "test_examples", "terragrunt-infrastructure-live-example", "non-prod"),
 	})
 }

--- a/cmd/golden/filterInfraLiveNonProd.yaml
+++ b/cmd/golden/filterInfraLiveNonProd.yaml
@@ -1,0 +1,41 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: non-prod/us-east-1/qa/mysql
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: non-prod/us-east-1/qa/webserver-cluster
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: non-prod/us-east-1/stage/mysql
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: non-prod/us-east-1/stage/webserver-cluster
+version: 3

--- a/cmd/golden/filterInfraLiveProd.yaml
+++ b/cmd/golden/filterInfraLiveProd.yaml
@@ -1,0 +1,23 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: prod/us-east-1/prod/mysql
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: prod/us-east-1/prod/webserver-cluster
+version: 3


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- runatlantis/atlantis#1466

## Description

I was originally using the root flag for this but realized this caused
unintended issues with Atlantis and how the pattern matching is done.

This provides an additional flag "--filter" that is passed to
FindConfigFilesInPath() to only search a sub-path based on root.

## Security Implications

- None

## System Availability

- All
