### PR TITLE
Always include ApplyRequirements in output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.2.1
+VERSION=1.3.0
 PATH_BUILD=build/
 FILE_COMMAND=terragrunt-atlantis-config
 FILE_ARCH=darwin_amd64

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then, make sure `terragrunt-atlantis-config` is present on your Atlantis server.
 
 ```hcl
 variable "terragrunt_atlantis_config_version" {
-  default = "1.2.1"
+  default = "1.3.0"
 }
 
 build {
@@ -92,7 +92,8 @@ locals {
 In your `atlantis.yaml` file, you will end up seeing output like:
 
 ```yaml
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
       - "*.hcl"
@@ -168,7 +169,7 @@ You can install this tool locally to checkout what kinds of config it will gener
 Recommended: Install any version via go get:
 
 ```bash
-cd && GO111MODULE=on go get github.com/transcend-io/terragrunt-atlantis-config@v1.2.1 && cd -
+cd && GO111MODULE=on go get github.com/transcend-io/terragrunt-atlantis-config@v1.3.0 && cd -
 ```
 
 This module officially supports golang versions v1.13, v1.14, and v1.15, tested on CircleCI with each build

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -50,7 +50,7 @@ type AtlantisProject struct {
 	// The terraform version to use for this project
 	TerraformVersion string `json:"terraform_version,omitempty"`
 
-	ApplyRequirements []string `json:"apply_requirements,omitempty"`
+	ApplyRequirements []string `json:"apply_requirements,flow"`
 }
 
 // Autoplan settings for which plans affect other plans

--- a/cmd/golden/autoplan.yaml
+++ b/cmd/golden/autoplan.yaml
@@ -2,19 +2,22 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
   dir: autoplan_false
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: true
     when_modified:
     - '*.hcl'
     - '*.tf*'
   dir: autoplan_true
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: true
     when_modified:
     - '*.hcl'

--- a/cmd/golden/basic.yaml
+++ b/cmd/golden/basic.yaml
@@ -2,7 +2,8 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/chained_dependency.yaml
+++ b/cmd/golden/chained_dependency.yaml
@@ -2,20 +2,23 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
   dir: dependency
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
     - ../dependency/terragrunt.hcl
   dir: depender
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
@@ -24,7 +27,8 @@ projects:
     - ../dependency/terragrunt.hcl
     - nested/terragrunt.hcl
   dir: depender_on_depender
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/chained_dependency_no_flag.yaml
+++ b/cmd/golden/chained_dependency_no_flag.yaml
@@ -2,20 +2,23 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
   dir: dependency
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
     - ../dependency/terragrunt.hcl
   dir: depender
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
@@ -23,7 +26,8 @@ projects:
     - ../depender/terragrunt.hcl
     - nested/terragrunt.hcl
   dir: depender_on_depender
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/different_workflow_names.yaml
+++ b/cmd/golden/different_workflow_names.yaml
@@ -2,20 +2,23 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
   dir: defaultWorkflow
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
   dir: workflowA
   workflow: workflowA
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/extraArguments.yaml
+++ b/cmd/golden/extraArguments.yaml
@@ -2,7 +2,8 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
@@ -13,13 +14,15 @@ projects:
     - dev.tfvars
     - us-east-1.tfvars
   dir: child
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
   dir: no_files_at_all
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
@@ -29,14 +32,16 @@ projects:
     - dev.tfvars
     - us-east-1.tfvars
   dir: only_optional_files
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
     - ../terraform.tfvars
   dir: only_required_files
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/extra_dependencies.yaml
+++ b/cmd/golden/extra_dependencies.yaml
@@ -2,7 +2,8 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/filterInfraLiveNonProd.yaml
+++ b/cmd/golden/filterInfraLiveNonProd.yaml
@@ -2,7 +2,8 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
@@ -11,7 +12,8 @@ projects:
     - ../../region.hcl
     - ../env.hcl
   dir: non-prod/us-east-1/qa/mysql
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
@@ -20,7 +22,8 @@ projects:
     - ../../region.hcl
     - ../env.hcl
   dir: non-prod/us-east-1/qa/webserver-cluster
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
@@ -29,7 +32,8 @@ projects:
     - ../../region.hcl
     - ../env.hcl
   dir: non-prod/us-east-1/stage/mysql
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/filterInfraLiveProd.yaml
+++ b/cmd/golden/filterInfraLiveProd.yaml
@@ -2,7 +2,8 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
@@ -11,7 +12,8 @@ projects:
     - ../../region.hcl
     - ../env.hcl
   dir: prod/us-east-1/prod/mysql
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/infrastructureLive.yaml
+++ b/cmd/golden/infrastructureLive.yaml
@@ -2,7 +2,8 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
@@ -11,7 +12,8 @@ projects:
     - ../../region.hcl
     - ../env.hcl
   dir: non-prod/us-east-1/qa/mysql
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
@@ -20,7 +22,8 @@ projects:
     - ../../region.hcl
     - ../env.hcl
   dir: non-prod/us-east-1/qa/webserver-cluster
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
@@ -29,7 +32,8 @@ projects:
     - ../../region.hcl
     - ../env.hcl
   dir: non-prod/us-east-1/stage/mysql
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
@@ -38,7 +42,8 @@ projects:
     - ../../region.hcl
     - ../env.hcl
   dir: non-prod/us-east-1/stage/webserver-cluster
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
@@ -47,7 +52,8 @@ projects:
     - ../../region.hcl
     - ../env.hcl
   dir: prod/us-east-1/prod/mysql
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/invalid_parent_module.yaml
+++ b/cmd/golden/invalid_parent_module.yaml
@@ -2,7 +2,8 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/local_terraform_module.yaml
+++ b/cmd/golden/local_terraform_module.yaml
@@ -2,7 +2,8 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/mergeParentDependencies.yaml
+++ b/cmd/golden/mergeParentDependencies.yaml
@@ -2,7 +2,8 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
@@ -12,7 +13,8 @@ projects:
     - ../../parent/folder_under_parent/common_tags.hcl
     - some_child_dep
   dir: deep/child
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/multi_accounts_vpc_route53_tgw.yaml
+++ b/cmd/golden/multi_accounts_vpc_route53_tgw.yaml
@@ -2,13 +2,15 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
   dir: network-account/eu-west-1/network/transit-gateway
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
@@ -16,7 +18,8 @@ projects:
     - ../../../env-a/network/vpc/terragrunt.hcl
     - ../../../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
   dir: prod/eu-west-1/_global/route53/test-zone
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/namedWorkflow.yaml
+++ b/cmd/golden/namedWorkflow.yaml
@@ -2,7 +2,8 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/noParallel.yaml
+++ b/cmd/golden/noParallel.yaml
@@ -2,7 +2,8 @@ automerge: false
 parallel_apply: false
 parallel_plan: false
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/no_terraform_blocks.yml
+++ b/cmd/golden/no_terraform_blocks.yml
@@ -2,7 +2,8 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: true
     when_modified:
     - '*.hcl'
@@ -10,33 +11,38 @@ projects:
     - ../network/terragrunt.hcl
     - ../../stage/network/terragrunt.hcl
   dir: myproject/eu-south-1/infra/apps
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: true
     when_modified:
     - '*.hcl'
     - '*.tf*'
     - ../../stage/network/terragrunt.hcl
   dir: myproject/eu-south-1/infra/network
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: true
     when_modified:
     - '*.hcl'
     - '*.tf*'
     - ../network/terragrunt.hcl
   dir: myproject/eu-south-1/stage/dbs
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: true
     when_modified:
     - '*.hcl'
     - '*.tf*'
   dir: myproject/eu-south-1/stage/network
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: true
     when_modified:
     - '*.hcl'
     - '*.tf*'
   dir: myproject/global/dns
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: true
     when_modified:
     - '*.hcl'

--- a/cmd/golden/oldWorkflowsPreserved.yaml
+++ b/cmd/golden/oldWorkflowsPreserved.yaml
@@ -2,7 +2,8 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/parentAndChildDefinedWorkflow.yaml
+++ b/cmd/golden/parentAndChildDefinedWorkflow.yaml
@@ -2,7 +2,8 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/parentDefinedWorkflow.yaml
+++ b/cmd/golden/parentDefinedWorkflow.yaml
@@ -2,7 +2,8 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/skip.yaml
+++ b/cmd/golden/skip.yaml
@@ -2,7 +2,8 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/terraform_version.yaml
+++ b/cmd/golden/terraform_version.yaml
@@ -2,21 +2,24 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
   dir: inherit_from_parent
   terraform_version: 0.12.9001
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
   dir: override_parent
   terraform_version: 0.13.9001
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/terragrunt_dependency.yaml
+++ b/cmd/golden/terragrunt_dependency.yaml
@@ -2,13 +2,15 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
   dir: dependency
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/terragrunt_dependency_ignored.yaml
+++ b/cmd/golden/terragrunt_dependency_ignored.yaml
@@ -2,13 +2,15 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
   dir: dependency
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/withAutomerge.yaml
+++ b/cmd/golden/withAutomerge.yaml
@@ -2,7 +2,8 @@ automerge: true
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/withAutoplan.yaml
+++ b/cmd/golden/withAutoplan.yaml
@@ -2,7 +2,8 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: true
     when_modified:
     - '*.hcl'

--- a/cmd/golden/withParent.yaml
+++ b/cmd/golden/withParent.yaml
@@ -2,13 +2,15 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
   dir: .
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/withProjectName.yaml
+++ b/cmd/golden/withProjectName.yaml
@@ -2,7 +2,8 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/withWorkspace.yaml
+++ b/cmd/golden/withWorkspace.yaml
@@ -2,7 +2,8 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/cmd/golden/withoutParent.yaml
+++ b/cmd/golden/withoutParent.yaml
@@ -2,7 +2,8 @@ automerge: false
 parallel_apply: true
 parallel_plan: true
 projects:
-- autoplan:
+- apply_requirements: []
+  autoplan:
     enabled: false
     when_modified:
     - '*.hcl'

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import "github.com/transcend-io/terragrunt-atlantis-config/cmd"
 // This variable is set at build time using -ldflags parameters.
 // But we still set a default here for those using plain `go get` downloads
 // For more info, see: http://stackoverflow.com/a/11355611/483528
-var VERSION string = "1.2.1"
+var VERSION string = "1.3.0"
 
 func main() {
 	cmd.Execute(VERSION)


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- Closes https://github.com/transcend-io/terragrunt-atlantis-config/issues/128

## Description

Always includes apply requirements in output. In general, server config should dictate the apply requirements because they are not changeable by developers within a PR. However, there is the option in Atlantis to allow overriding apply requirements for certain workflows in the repo level config file.
