### PR TITLE
Add possibility to use glob expressions with --filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ One way to customize the behavior of this module is through CLI flag values pass
 | `--root`                     | Path to the root directory of the git repo you want to build config for.                                                                                                        | current directory |
 | `--terraform-version`        | Default terraform version to specify for all modules. Can be overriden by locals                                                                                                | ""                |
 | `--ignore-dependency-blocks` | When true, dependencies found in `dependency` and `dependencies` blocks will be ignored                                                                                         | false             |
-| `--filter`                   | Path to the directory you want scope down the config for. Default is all files in root                                                                                          | ""                |
+| `--filter`                   | Path or glob expression to the directory you want scope down the config for. Default is all files in root                                                                                          | ""                |
 
 ## All Locals
 

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -387,3 +387,12 @@ func TestFilterFlagWithInfraLiveNonProd(t *testing.T) {
 		filepath.Join("..", "test_examples", "terragrunt-infrastructure-live-example", "non-prod"),
 	})
 }
+
+func TestFilterGlobFlagWithInfraLiveMySql(t *testing.T) {
+	runTest(t, filepath.Join("golden", "filterGlobInfraLiveMySQL.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "terragrunt-infrastructure-live-example"),
+		"--filter",
+		filepath.Join("..", "test_examples", "terragrunt-infrastructure-live-example", "*", "*", "*", "mysql"),
+	})
+}

--- a/cmd/golden/filterGlobInfraLiveMySQL.yaml
+++ b/cmd/golden/filterGlobInfraLiveMySQL.yaml
@@ -1,0 +1,32 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: non-prod/us-east-1/qa/mysql
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: non-prod/us-east-1/stage/mysql
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: prod/us-east-1/prod/mysql
+version: 3


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- _[none]_

## Description

The current `--filter` implementation supports filtering by changing the base path. Consider the following layout and the requirement to run region1 modules in an atlantis instance hosted in region1 and region2 modules in an atlantis instance hosted in region2:
```
live
  region1
    modules-r1
  region2
    modules-r2
stage
  region1
    modules-r1
  region2
    modules-r2
```

The proposed extension of the `--filter` parameter for supporting glob expressions will allow for the generation of region specific configs:
`--filter "*/region1"` and `--filter "*/region2"`

The existing behaviour of the `--filter` parameter is not affected.

## Security Implications

- _[none]_

## System Availability

- _[none]_
