### PR TITLE
Make Github Actions compile statically linked binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build: clean
     -bc="darwin,amd64" \
     -pv=$(VERSION) \
     -d=$(PATH_BUILD) \
-    -build-ldflags "-X main.VERSION=$(VERSION)"
+    -build-ldflags "-X main.VERSION=$(VERSION) -extldflags=-static"
 
 .PHONY: build-all
 build-all: clean
@@ -29,7 +29,7 @@ build-all: clean
 	-arch="$(XC_ARCH)" \
     -pv=$(VERSION) \
     -d=$(PATH_BUILD) \
-    -build-ldflags "-X main.VERSION=$(VERSION)"
+    -build-ldflags "-X main.VERSION=$(VERSION) -extldflags=-static"
 
 .PHONY: gotestsum
 gotestsum:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.5.0
+VERSION=1.5.1
 PATH_BUILD=build/
 FILE_COMMAND=terragrunt-atlantis-config
 FILE_ARCH=darwin_amd64

--- a/Makefile
+++ b/Makefile
@@ -16,20 +16,22 @@ clean:
 
 .PHONY: build
 build: clean
+	CGO_ENABLED=0 \
 	goxc \
     -bc="darwin,amd64" \
     -pv=$(VERSION) \
     -d=$(PATH_BUILD) \
-    -build-ldflags "-X main.VERSION=$(VERSION) -extldflags=-static"
+    -build-ldflags "-X main.VERSION=$(VERSION)"
 
 .PHONY: build-all
 build-all: clean
+	CGO_ENABLED=0 \
 	goxc \
 	-os="$(XC_OS)" \
 	-arch="$(XC_ARCH)" \
     -pv=$(VERSION) \
     -d=$(PATH_BUILD) \
-    -build-ldflags "-X main.VERSION=$(VERSION) -extldflags=-static"
+    -build-ldflags "-X main.VERSION=$(VERSION)"
 
 .PHONY: gotestsum
 gotestsum:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then, make sure `terragrunt-atlantis-config` is present on your Atlantis server.
 
 ```hcl
 variable "terragrunt_atlantis_config_version" {
-  default = "1.5.0"
+  default = "1.5.1"
 }
 
 build {
@@ -168,7 +168,7 @@ You can install this tool locally to checkout what kinds of config it will gener
 Recommended: Install any version via go get:
 
 ```bash
-cd && GO111MODULE=on go get github.com/transcend-io/terragrunt-atlantis-config@v1.5.0 && cd -
+cd && GO111MODULE=on go get github.com/transcend-io/terragrunt-atlantis-config@v1.5.1 && cd -
 ```
 
 This module officially supports golang versions v1.13, v1.14, v1.15, and v1.16, tested on CircleCI with each build

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import "github.com/transcend-io/terragrunt-atlantis-config/cmd"
 // This variable is set at build time using -ldflags parameters.
 // But we still set a default here for those using plain `go get` downloads
 // For more info, see: http://stackoverflow.com/a/11355611/483528
-var VERSION string = "1.5.0"
+var VERSION string = "1.5.1"
 
 func main() {
 	cmd.Execute(VERSION)


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- https://github.com/transcend-io/terragrunt-atlantis-config/issues/139

## Description

This makes compiled binaries statically linked, like they were at version 1.3.1 and lower.
Since version 1.4.1 (a.k.a moving to GitHub Actions), binaries started being dynamically linked, causing issues when running them on systems without proper libs installed (such as in a vanilla alpine Docker image).

I've compiled binaries with this code and they're available on https://github.com/gmpify/terragrunt-atlantis-config/releases/tag/v1.5.1; checking linux amd64:
```
$ file terragrunt-atlantis-config_1.5.1_linux_amd64
terragrunt-atlantis-config_1.5.1_linux_amd64: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=ETb7DcNyniNFkCi44IA2/iwvjiNliFGxrOJzQgHLP/Aim_1kHlIp5viEyZprY1/J8ZfmICRWG-rVD_pJE0C, not stripped
```

## Security Implications

- _[none]_

## System Availability

- _[none]_
