### PR TITLE
add test case that shows failing parallel generation

### DIFF
--- a/test_examples/invalid_parent_module/child/deep-2/terragrunt.hcl
+++ b/test_examples/invalid_parent_module/child/deep-2/terragrunt.hcl
@@ -1,0 +1,11 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/invalid_parent_module/child/deep-3/terragrunt.hcl
+++ b/test_examples/invalid_parent_module/child/deep-3/terragrunt.hcl
@@ -1,0 +1,11 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+inputs = {
+  foo = "bar"
+}


### PR DESCRIPTION
# Pull Request

This PR extends an existing test case to show the non-consistent ordering of projects in the generated file.

## Related Github Issues

-  #145