### PR TITLE
Support Terraform Registry module sources

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -138,7 +138,7 @@ func getDependencies(path string, terragruntOptions *options.TerragruntOptions) 
 		if parsedConfig.Terraform != nil && parsedConfig.Terraform.Source != nil {
 			source := parsedConfig.Terraform.Source
 			// TODO: Make more robust. Check for bitbucket, etc.
-			if !strings.Contains(*source, "git::") && !strings.Contains(*source, "github.com") {
+			if !strings.Contains(*source, "git::") && !strings.Contains(*source, "github.com") && !strings.Contains(*source, "tfr:///") {
 				dependencies = append(dependencies, filepath.Join(*source, "*.tf*"))
 
 				var dir string

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -424,3 +424,10 @@ func TestMultipleIncludes(t *testing.T) {
 		"--terraform-version", "0.14.9001",
 	})
 }
+
+func TestTerraformRegistryModule(t *testing.T) {
+	runTest(t, filepath.Join("golden", "basic.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "terraform_registry_module_source"),
+	})
+}

--- a/test_examples/terraform_registry_module_source/terragrunt.hcl
+++ b/test_examples/terraform_registry_module_source/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "tfr:///terraform-aws-modules/vpc/aws?version=3.7.0"
+}
+
+inputs = {
+  foo = "bar"
+}


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- #172

## Description

Support Terraform Registry module sources, denoted by a source string containing `tfr:///`.

## Security Implications

- _[none]_

## System Availability

- _[none]_
