### PR TITLE
support get_original_terragrunt_dir function

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -203,6 +203,7 @@ func getDependencies(path string, terragruntOptions *options.TerragruntOptions) 
 
 			depPath := dep
 			terrOpts, _ := options.NewTerragruntOptions(depPath)
+			terrOpts.OriginalTerragruntConfigPath = terragruntOptions.OriginalTerragruntConfigPath
 			childDeps, err := getDependencies(depPath, terrOpts)
 			if err != nil {
 				continue
@@ -265,6 +266,7 @@ func createProject(sourcePath string) (*AtlantisProject, error) {
 	if err != nil {
 		return nil, err
 	}
+	options.OriginalTerragruntConfigPath = sourcePath
 	options.RunTerragrunt = cli.RunTerragrunt
 	options.Env = getEnvs()
 


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- _[none]_

## Description

To support get_original_terragrunt_dir() build-in function, correct value of OriginalTerragruntConfigPath is a must.

I propose to initialize the variable when creating project.

## Security Implications

- _[none]_

## System Availability

- _[none]_
