### PR TITLE
Project hcl files

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,17 @@ One way to customize the behavior of this module is through CLI flag values pass
 | `--filter`                   | Path or glob expression to the directory you want scope down the config for. Default is all files in root                                                                                          | ""                |
 | `--num-executors`                   | Number of executors used for parallel generation of projects. Default is 15                                                                                          | 15                |
 
+## Project generation
+
+These flags offer additional options to generate Atlantis projects based on HCL configuration files in the terragrunt hierarchy. This, for example, enables Atlantis to use `terragrunt run-all` workflows on staging environment or product levels in a terragrunt hierarchy. Mostly useful in large terragrunt projects containing lots of interdependent child modules. Atlantis `locals` can be used in the defined project marker files.
+
+| Flag Name                    | Description                                                                                                                                                                     | Default Value     | Type |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |----- |
+| `--project-hcl-files`        | Comma-separated names of arbitrary hcl files in the terragrunt hierarchy to create Atlantis projects for.<br>Disables the `--filter` flag  | ""      |  list(string) |
+| `--use-project-markers`      | If enabled, project hcl files must include `locals { atlantis_project = true }` for project creation.  | false      |  bool |
+| `--create-hcl-project-childs`        | Creates Atlantis projects for terragrunt child modules below the directories containing the HCL files defined in --project-hcl-files  | false       | bool |
+| `--create-hcl-project-external-childs`    | Creates Atlantis projects for terragrunt child modules outside the directories containing the HCL files defined in --project-hcl-files  | true          | bool |
+
 ## All Locals
 
 Another way to customize the output is to use `locals` values in your terragrunt modules. These can be set in either the parent or child terragrunt modules, and the settings will only affect the current module (or all child modules for parent locals).
@@ -143,6 +154,7 @@ Another way to customize the output is to use `locals` values in your terragrunt
 | `atlantis_autoplan`           | Allows overriding the `--autoplan` flag for a single module                                                                                                    | bool         |
 | `atlantis_skip`               | If true on a child module, that module will not appear in the output.<br>If true on a parent module, none of that parent's children will appear in the output. | bool         |
 | `extra_atlantis_dependencies` | See [Extra dependencies](https://github.com/transcend-io/terragrunt-atlantis-config#extra-dependencies)                                                        | list(string) |
+| `atlantis_project`            | Create Atlantis project for a project hcl file. Only functional with `--project-hcl-files` and `--use-project-markers` | bool         |
 
 ## Separate workspace for parallel plan and apply
 

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -39,6 +39,10 @@ func resetForRun() error {
 	outputPath = ""
 	defaultTerraformVersion = ""
 	defaultApplyRequirements = []string{}
+	projectHclFiles = []string{}
+	createHclProjectChilds = false
+	createHclProjectExternalChilds = true
+	useProjectMarkers = false
 
 	return nil
 }
@@ -429,5 +433,54 @@ func TestTerraformRegistryModule(t *testing.T) {
 	runTest(t, filepath.Join("golden", "basic.yaml"), []string{
 		"--root",
 		filepath.Join("..", "test_examples", "terraform_registry_module_source"),
+	})
+}
+
+func TestEnvHCLProjectsNoChilds(t *testing.T) {
+	runTest(t, filepath.Join("golden", "envhcl_nochilds.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples"),
+		"--project-hcl-files=env.hcl",
+		"--create-hcl-project-childs=false",
+		"--create-hcl-project-external-childs=false",
+	})
+}
+
+func TestEnvHCLProjectsSubChilds(t *testing.T) {
+	runTest(t, filepath.Join("golden", "envhcl_subchilds.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples"),
+		"--project-hcl-files=env.hcl",
+		"--create-hcl-project-childs=true",
+		"--create-hcl-project-external-childs=false",
+	})
+}
+
+func TestEnvHCLProjectsExternalChilds(t *testing.T) {
+	runTest(t, filepath.Join("golden", "envhcl_externalchilds.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples"),
+		"--project-hcl-files=env.hcl",
+		"--create-hcl-project-childs=false",
+		"--create-hcl-project-external-childs=true",
+	})
+}
+
+func TestEnvHCLProjectsAllChilds(t *testing.T) {
+	runTest(t, filepath.Join("golden", "envhcl_allchilds.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples"),
+		"--project-hcl-files=env.hcl",
+		"--create-hcl-project-childs=true",
+		"--create-hcl-project-external-childs=true",
+	})
+}
+
+func TestEnvHCLProjectMarker(t *testing.T) {
+	runTest(t, filepath.Join("golden", "project_marker.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "project_hcl_with_project_marker"),
+		"--project-hcl-files=env.hcl",
+		"--use-project-markers=true",
 	})
 }

--- a/cmd/golden/envhcl_allchilds.yaml
+++ b/cmd/golden/envhcl_allchilds.yaml
@@ -1,0 +1,642 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- apply_requirements:
+  - approved
+  autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: apply_requirements_overrides/child_that_does_not_override
+- apply_requirements:
+  - mergeable
+  autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: apply_requirements_overrides/child_that_overrides
+- apply_requirements: []
+  autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: apply_requirements_overrides/child_that_overrides_to_empty
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: apply_requirements_overrides/standalone_module_that_does_not_specify
+- apply_requirements:
+  - mergeable
+  autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: apply_requirements_overrides/standalone_module_that_specifies
+- apply_requirements: []
+  autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: apply_requirements_overrides/standalone_module_that_specifies_empty
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: autoplan/autoplan_false
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: autoplan/autoplan_true
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: autoplan/set_in_parent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: basic_module
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: chained_dependencies/dependency
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../dependency/terragrunt.hcl
+  dir: chained_dependencies/depender
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../depender/terragrunt.hcl
+    - ../dependency/terragrunt.hcl
+    - nested/terragrunt.hcl
+  dir: chained_dependencies/depender_on_depender
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../dependency/terragrunt.hcl
+  dir: chained_dependencies/depender_on_depender/nested
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: child_and_parent_specify_workflow/child
+  workflow: workflowSpecifiedInChild
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: different_workflow_names/defaultWorkflow
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: different_workflow_names/workflowA
+  workflow: workflowA
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: different_workflow_names/workflowB
+  workflow: workflowB
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../terraform.tfvars
+    - ../dev.tfvars
+    - ../us-east-1.tfvars
+    - dev.tfvars
+    - us-east-1.tfvars
+  dir: extra_arguments/child
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: extra_arguments/no_files_at_all
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../dev.tfvars
+    - ../us-east-1.tfvars
+    - dev.tfvars
+    - us-east-1.tfvars
+  dir: extra_arguments/only_optional_files
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../terraform.tfvars
+  dir: extra_arguments/only_required_files
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../../common_vars/apps/consul/sg.tfvars
+    - main.tfvars
+  dir: extra_arguments/var_file
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - some_extra_dep
+    - ../test_file.json
+  dir: extra_dependency/child
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+  dir: invalid_parent_module/child
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: invalid_parent_module/child/deep
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../root-module/*.tf*
+    - ../terraform-module/*.tf*
+  dir: local_terraform_abs_module_source/terragrunt-module
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../root-module/*.tf*
+    - ../terraform-module/*.tf*
+  dir: local_terraform_module_source/terragrunt-module
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../terraform-another-module/*.tf*
+    - ../terraform-module/*.tf*
+    - ../terraform-module/nested-module/*.tf*
+  dir: local_tf_module_source/terraform
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+  dir: multi_accounts_vpc_route53_tgw/network-account/eu-west-1/network
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: multi_accounts_vpc_route53_tgw/network-account/eu-west-1/network/transit-gateway
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../env-a/network/vpc/terragrunt.hcl
+    - ../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
+  dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/_global
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../env-a/network/vpc/terragrunt.hcl
+    - ../../../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
+  dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/_global/route53/test-zone
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
+  dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/env-a
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
+  dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/env-a/network/vpc
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: multiple_includes/includes_tf_12_then_13
+  terraform_version: 0.13.9001
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: multiple_includes/includes_tf_13_then_12
+  terraform_version: 0.12.9001
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: multiple_includes/uses_terraform_12
+  terraform_version: 0.12.9001
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: multiple_includes/uses_terraform_13
+  terraform_version: 0.13.9001
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../stage/network/terragrunt.hcl
+  dir: no_terraform_blocks/myproject/eu-south-1/infra
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../network/terragrunt.hcl
+    - ../../stage/network/terragrunt.hcl
+  dir: no_terraform_blocks/myproject/eu-south-1/infra/apps
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../stage/network/terragrunt.hcl
+  dir: no_terraform_blocks/myproject/eu-south-1/infra/network
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+  dir: no_terraform_blocks/myproject/eu-south-1/stage
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../network/terragrunt.hcl
+  dir: no_terraform_blocks/myproject/eu-south-1/stage/dbs
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: no_terraform_blocks/myproject/eu-south-1/stage/network
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+  dir: no_terraform_blocks/myproject/global
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: no_terraform_blocks/myproject/global/dns
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: no_terraform_blocks/myproject/global/iam
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - some_parent_dep
+    - ../file_in_parent_of_child.json
+    - ../../parent/folder_under_parent/common_tags.hcl
+    - some_child_dep
+  dir: parent_with_extra_deps/deep/child
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - some_parent_dep
+    - local_tags.yaml
+    - ../file_in_parent_of_child.json
+    - ../../parent/folder_under_parent/common_tags.hcl
+    - some_child_dep
+  dir: parent_with_extra_deps/deep_with_local_tags_file/child
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: parent_with_workflow_local/child
+  workflow: workflowSpecifiedInParent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+    - ../../arbitrary.hcl
+    - ../stage/**/*.hcl
+  dir: project_hcl_with_atlantis_locals/non-prod/us-east-1/qa
+  workflow: anotherWorkflowSpecifiedInParent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: project_hcl_with_atlantis_locals/non-prod/us-east-1/qa/mysql
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: project_hcl_with_atlantis_locals/non-prod/us-east-1/qa/webserver-cluster
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: project_hcl_with_atlantis_locals/non-prod/us-east-1/stage
+  workflow: workflowSpecifiedInParent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: project_hcl_with_atlantis_locals/non-prod/us-east-1/stage/mysql
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: project_hcl_with_atlantis_locals/non-prod/us-east-1/stage/webserver-cluster
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+    - ../../arbitrary.hcl
+    - ../stage/**/*.hcl
+  dir: project_hcl_with_project_marker/non-prod/us-east-1/qa
+  workflow: anotherWorkflowSpecifiedInParent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: project_hcl_with_project_marker/non-prod/us-east-1/qa/mysql
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: project_hcl_with_project_marker/non-prod/us-east-1/qa/webserver-cluster
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: project_hcl_with_project_marker/non-prod/us-east-1/stage
+  workflow: workflowSpecifiedInParent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: project_hcl_with_project_marker/non-prod/us-east-1/stage/mysql
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: project_hcl_with_project_marker/non-prod/us-east-1/stage/webserver-cluster
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: skip/skip_false
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: terraform_registry_module_source
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: terraform_version/inherit_from_parent
+  terraform_version: 0.12.9001
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: terraform_version/override_parent
+  terraform_version: 0.13.9001
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: terraform_version/use_flag_default
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/qa
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/qa/mysql
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/qa/webserver-cluster
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/stage
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/stage/mysql
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/stage/webserver-cluster
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: terragrunt-infrastructure-live-example/prod/us-east-1/prod
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: terragrunt-infrastructure-live-example/prod/us-east-1/prod/mysql
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: terragrunt-infrastructure-live-example/prod/us-east-1/prod/webserver-cluster
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: terragrunt_dependency/dependency
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../dependency/terragrunt.hcl
+  dir: terragrunt_dependency/depender
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: with_parent/child
+version: 3

--- a/cmd/golden/envhcl_externalchilds.yaml
+++ b/cmd/golden/envhcl_externalchilds.yaml
@@ -1,0 +1,449 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- apply_requirements:
+  - approved
+  autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: apply_requirements_overrides/child_that_does_not_override
+- apply_requirements:
+  - mergeable
+  autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: apply_requirements_overrides/child_that_overrides
+- apply_requirements: []
+  autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: apply_requirements_overrides/child_that_overrides_to_empty
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: apply_requirements_overrides/standalone_module_that_does_not_specify
+- apply_requirements:
+  - mergeable
+  autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: apply_requirements_overrides/standalone_module_that_specifies
+- apply_requirements: []
+  autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: apply_requirements_overrides/standalone_module_that_specifies_empty
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: autoplan/autoplan_false
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: autoplan/autoplan_true
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: autoplan/set_in_parent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: basic_module
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: chained_dependencies/dependency
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../dependency/terragrunt.hcl
+  dir: chained_dependencies/depender
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../depender/terragrunt.hcl
+    - ../dependency/terragrunt.hcl
+    - nested/terragrunt.hcl
+  dir: chained_dependencies/depender_on_depender
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../dependency/terragrunt.hcl
+  dir: chained_dependencies/depender_on_depender/nested
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: child_and_parent_specify_workflow/child
+  workflow: workflowSpecifiedInChild
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: different_workflow_names/defaultWorkflow
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: different_workflow_names/workflowA
+  workflow: workflowA
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: different_workflow_names/workflowB
+  workflow: workflowB
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../terraform.tfvars
+    - ../dev.tfvars
+    - ../us-east-1.tfvars
+    - dev.tfvars
+    - us-east-1.tfvars
+  dir: extra_arguments/child
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: extra_arguments/no_files_at_all
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../dev.tfvars
+    - ../us-east-1.tfvars
+    - dev.tfvars
+    - us-east-1.tfvars
+  dir: extra_arguments/only_optional_files
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../terraform.tfvars
+  dir: extra_arguments/only_required_files
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../../common_vars/apps/consul/sg.tfvars
+    - main.tfvars
+  dir: extra_arguments/var_file
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - some_extra_dep
+    - ../test_file.json
+  dir: extra_dependency/child
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+  dir: invalid_parent_module/child
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../root-module/*.tf*
+    - ../terraform-module/*.tf*
+  dir: local_terraform_abs_module_source/terragrunt-module
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../root-module/*.tf*
+    - ../terraform-module/*.tf*
+  dir: local_terraform_module_source/terragrunt-module
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../terraform-another-module/*.tf*
+    - ../terraform-module/*.tf*
+    - ../terraform-module/nested-module/*.tf*
+  dir: local_tf_module_source/terraform
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+  dir: multi_accounts_vpc_route53_tgw/network-account/eu-west-1/network
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../env-a/network/vpc/terragrunt.hcl
+    - ../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
+  dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/_global
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
+  dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/env-a
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: multiple_includes/includes_tf_12_then_13
+  terraform_version: 0.13.9001
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: multiple_includes/includes_tf_13_then_12
+  terraform_version: 0.12.9001
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: multiple_includes/uses_terraform_12
+  terraform_version: 0.12.9001
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: multiple_includes/uses_terraform_13
+  terraform_version: 0.13.9001
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../stage/network/terragrunt.hcl
+  dir: no_terraform_blocks/myproject/eu-south-1/infra
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+  dir: no_terraform_blocks/myproject/eu-south-1/stage
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+  dir: no_terraform_blocks/myproject/global
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - some_parent_dep
+    - ../file_in_parent_of_child.json
+    - ../../parent/folder_under_parent/common_tags.hcl
+    - some_child_dep
+  dir: parent_with_extra_deps/deep/child
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - some_parent_dep
+    - local_tags.yaml
+    - ../file_in_parent_of_child.json
+    - ../../parent/folder_under_parent/common_tags.hcl
+    - some_child_dep
+  dir: parent_with_extra_deps/deep_with_local_tags_file/child
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: parent_with_workflow_local/child
+  workflow: workflowSpecifiedInParent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+    - ../../arbitrary.hcl
+    - ../stage/**/*.hcl
+  dir: project_hcl_with_atlantis_locals/non-prod/us-east-1/qa
+  workflow: anotherWorkflowSpecifiedInParent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: project_hcl_with_atlantis_locals/non-prod/us-east-1/stage
+  workflow: workflowSpecifiedInParent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+    - ../../arbitrary.hcl
+    - ../stage/**/*.hcl
+  dir: project_hcl_with_project_marker/non-prod/us-east-1/qa
+  workflow: anotherWorkflowSpecifiedInParent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: project_hcl_with_project_marker/non-prod/us-east-1/stage
+  workflow: workflowSpecifiedInParent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: skip/skip_false
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: terraform_registry_module_source
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: terraform_version/inherit_from_parent
+  terraform_version: 0.12.9001
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: terraform_version/override_parent
+  terraform_version: 0.13.9001
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: terraform_version/use_flag_default
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/qa
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/stage
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: terragrunt-infrastructure-live-example/prod/us-east-1/prod
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: terragrunt_dependency/dependency
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../dependency/terragrunt.hcl
+  dir: terragrunt_dependency/depender
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: with_parent/child
+version: 3

--- a/cmd/golden/envhcl_nochilds.yaml
+++ b/cmd/golden/envhcl_nochilds.yaml
@@ -1,0 +1,143 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+  dir: invalid_parent_module/child
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+  dir: multi_accounts_vpc_route53_tgw/network-account/eu-west-1/network
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../env-a/network/vpc/terragrunt.hcl
+    - ../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
+  dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/_global
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
+  dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/env-a
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../stage/network/terragrunt.hcl
+  dir: no_terraform_blocks/myproject/eu-south-1/infra
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+  dir: no_terraform_blocks/myproject/eu-south-1/stage
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+  dir: no_terraform_blocks/myproject/global
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+    - ../../arbitrary.hcl
+    - ../stage/**/*.hcl
+  dir: project_hcl_with_atlantis_locals/non-prod/us-east-1/qa
+  workflow: anotherWorkflowSpecifiedInParent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: project_hcl_with_atlantis_locals/non-prod/us-east-1/stage
+  workflow: workflowSpecifiedInParent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+    - ../../arbitrary.hcl
+    - ../stage/**/*.hcl
+  dir: project_hcl_with_project_marker/non-prod/us-east-1/qa
+  workflow: anotherWorkflowSpecifiedInParent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: project_hcl_with_project_marker/non-prod/us-east-1/stage
+  workflow: workflowSpecifiedInParent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/qa
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/stage
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: terragrunt-infrastructure-live-example/prod/us-east-1/prod
+version: 3

--- a/cmd/golden/envhcl_subchilds.yaml
+++ b/cmd/golden/envhcl_subchilds.yaml
@@ -1,0 +1,336 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+  dir: invalid_parent_module/child
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: invalid_parent_module/child/deep
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+  dir: multi_accounts_vpc_route53_tgw/network-account/eu-west-1/network
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: multi_accounts_vpc_route53_tgw/network-account/eu-west-1/network/transit-gateway
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../env-a/network/vpc/terragrunt.hcl
+    - ../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
+  dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/_global
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../env-a/network/vpc/terragrunt.hcl
+    - ../../../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
+  dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/_global/route53/test-zone
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
+  dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/env-a
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
+  dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/env-a/network/vpc
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../stage/network/terragrunt.hcl
+  dir: no_terraform_blocks/myproject/eu-south-1/infra
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../network/terragrunt.hcl
+    - ../../stage/network/terragrunt.hcl
+  dir: no_terraform_blocks/myproject/eu-south-1/infra/apps
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../stage/network/terragrunt.hcl
+  dir: no_terraform_blocks/myproject/eu-south-1/infra/network
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+  dir: no_terraform_blocks/myproject/eu-south-1/stage
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../network/terragrunt.hcl
+  dir: no_terraform_blocks/myproject/eu-south-1/stage/dbs
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: no_terraform_blocks/myproject/eu-south-1/stage/network
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+  dir: no_terraform_blocks/myproject/global
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: no_terraform_blocks/myproject/global/dns
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: no_terraform_blocks/myproject/global/iam
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+    - ../../arbitrary.hcl
+    - ../stage/**/*.hcl
+  dir: project_hcl_with_atlantis_locals/non-prod/us-east-1/qa
+  workflow: anotherWorkflowSpecifiedInParent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: project_hcl_with_atlantis_locals/non-prod/us-east-1/qa/mysql
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: project_hcl_with_atlantis_locals/non-prod/us-east-1/qa/webserver-cluster
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: project_hcl_with_atlantis_locals/non-prod/us-east-1/stage
+  workflow: workflowSpecifiedInParent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: project_hcl_with_atlantis_locals/non-prod/us-east-1/stage/mysql
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: project_hcl_with_atlantis_locals/non-prod/us-east-1/stage/webserver-cluster
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+    - ../../arbitrary.hcl
+    - ../stage/**/*.hcl
+  dir: project_hcl_with_project_marker/non-prod/us-east-1/qa
+  workflow: anotherWorkflowSpecifiedInParent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: project_hcl_with_project_marker/non-prod/us-east-1/qa/mysql
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: project_hcl_with_project_marker/non-prod/us-east-1/qa/webserver-cluster
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: project_hcl_with_project_marker/non-prod/us-east-1/stage
+  workflow: workflowSpecifiedInParent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: project_hcl_with_project_marker/non-prod/us-east-1/stage/mysql
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: project_hcl_with_project_marker/non-prod/us-east-1/stage/webserver-cluster
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/qa
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/qa/mysql
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/qa/webserver-cluster
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/stage
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/stage/mysql
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/stage/webserver-cluster
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: terragrunt-infrastructure-live-example/prod/us-east-1/prod
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: terragrunt-infrastructure-live-example/prod/us-east-1/prod/mysql
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../../account.hcl
+    - ../../region.hcl
+    - ../env.hcl
+  dir: terragrunt-infrastructure-live-example/prod/us-east-1/prod/webserver-cluster
+version: 3

--- a/cmd/golden/project_hcl_with_atlantis_locals.yaml
+++ b/cmd/golden/project_hcl_with_atlantis_locals.yaml
@@ -1,0 +1,29 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+    - ../../arbitrary.hcl
+    - ../stage/**/*.hcl
+  dir: non-prod/us-east-1/qa
+  workflow: anotherWorkflowSpecifiedInParent
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+  dir: non-prod/us-east-1/stage
+  workflow: workflowSpecifiedInParent
+version: 3

--- a/cmd/golden/project_marker.yaml
+++ b/cmd/golden/project_marker.yaml
@@ -1,0 +1,18 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../../account.hcl
+    - ../region.hcl
+    - ../../arbitrary.hcl
+    - ../stage/**/*.hcl
+  dir: non-prod/us-east-1/qa
+  workflow: anotherWorkflowSpecifiedInParent
+version: 3

--- a/cmd/parse_locals.go
+++ b/cmd/parse_locals.go
@@ -34,6 +34,9 @@ type ResolvedLocals struct {
 
 	// Terraform version to use just for this project
 	TerraformVersion string
+
+	// If set to true, create Atlantis project
+	markedProject *bool
 }
 
 // parseHcl uses the HCL2 parser to parse the given string into an HCL file body.
@@ -71,6 +74,10 @@ func mergeResolvedLocals(parent ResolvedLocals, child ResolvedLocals) ResolvedLo
 
 	if child.Skip != nil {
 		parent.Skip = child.Skip
+	}
+
+	if child.markedProject != nil {
+		parent.markedProject = child.markedProject
 	}
 
 	if child.ApplyRequirements != nil || len(child.ApplyRequirements) > 0 {
@@ -155,6 +162,12 @@ func resolveLocals(localsAsCty cty.Value) ResolvedLocals {
 			_, val := it.Element()
 			resolved.ApplyRequirements = append(resolved.ApplyRequirements, val.AsString())
 		}
+	}
+
+	markedProject, ok := rawLocals["atlantis_project"]
+	if ok {
+		hasValue := markedProject.True()
+		resolved.markedProject = &hasValue
 	}
 
 	extraDependenciesAsCty, ok := rawLocals["extra_atlantis_dependencies"]

--- a/test_examples/empty/empty.hcl
+++ b/test_examples/empty/empty.hcl
@@ -1,0 +1,3 @@
+locals{
+    var = null
+}

--- a/test_examples/project_hcl_with_atlantis_locals/non-prod/account.hcl
+++ b/test_examples/project_hcl_with_atlantis_locals/non-prod/account.hcl
@@ -1,0 +1,7 @@
+# Set account-wide variables. These are automatically pulled in to configure the remote state bucket in the root
+# terragrunt.hcl configuration.
+locals {
+  account_name   = "non-prod"
+  aws_account_id = "replaceme" # TODO: replace me with your AWS account ID!
+  aws_profile    = "non-prod"
+}

--- a/test_examples/project_hcl_with_atlantis_locals/non-prod/arbitrary.hcl
+++ b/test_examples/project_hcl_with_atlantis_locals/non-prod/arbitrary.hcl
@@ -1,0 +1,3 @@
+locals {
+  some = "stuff"
+}

--- a/test_examples/project_hcl_with_atlantis_locals/non-prod/us-east-1/qa/env.hcl
+++ b/test_examples/project_hcl_with_atlantis_locals/non-prod/us-east-1/qa/env.hcl
@@ -1,0 +1,10 @@
+# Set common variables for the environment. This is automatically pulled in in the root terragrunt.hcl configuration to
+# feed forward to the child modules.
+locals {
+  environment = "qa"
+  extra_atlantis_dependencies = [
+    find_in_parent_folders("arbitrary.hcl"),
+    "${dirname(find_in_parent_folders("account.hcl"))}/us-east-1/stage/**/*.hcl",
+  ]
+  atlantis_workflow = "anotherWorkflowSpecifiedInParent"
+}

--- a/test_examples/project_hcl_with_atlantis_locals/non-prod/us-east-1/qa/mysql/terragrunt.hcl
+++ b/test_examples/project_hcl_with_atlantis_locals/non-prod/us-east-1/qa/mysql/terragrunt.hcl
@@ -1,0 +1,31 @@
+locals {
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+
+  # Extract out common variables for reuse
+  env = local.environment_vars.locals.environment
+}
+
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+terraform {
+  source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//mysql?ref=v0.3.0"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+inputs = {
+  name           = "mysql_${local.env}"
+  instance_class = "db.t2.micro"
+
+  allocated_storage = 20
+  storage_type      = "standard"
+
+  master_username = "admin"
+  # TODO: To avoid storing your DB password in the code, set it as the environment variable TF_VAR_master_password
+}
+

--- a/test_examples/project_hcl_with_atlantis_locals/non-prod/us-east-1/qa/webserver-cluster/terragrunt.hcl
+++ b/test_examples/project_hcl_with_atlantis_locals/non-prod/us-east-1/qa/webserver-cluster/terragrunt.hcl
@@ -1,0 +1,30 @@
+locals {
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+
+  # Extract out common variables for reuse
+  env = local.environment_vars.locals.environment
+}
+
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+terraform {
+  source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//asg-elb-service?ref=v0.3.0"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+inputs = {
+  name          = "webserver-example-${local.env}"
+  instance_type = "t2.micro"
+
+  min_size = 2
+  max_size = 2
+
+  server_port = 8080
+  elb_port    = 80
+}

--- a/test_examples/project_hcl_with_atlantis_locals/non-prod/us-east-1/region.hcl
+++ b/test_examples/project_hcl_with_atlantis_locals/non-prod/us-east-1/region.hcl
@@ -1,0 +1,5 @@
+# Set common variables for the region. This is automatically pulled in in the root terragrunt.hcl configuration to
+# configure the remote state bucket and pass forward to the child modules as inputs.
+locals {
+  aws_region = "us-east-1"
+}

--- a/test_examples/project_hcl_with_atlantis_locals/non-prod/us-east-1/stage/env.hcl
+++ b/test_examples/project_hcl_with_atlantis_locals/non-prod/us-east-1/stage/env.hcl
@@ -1,0 +1,6 @@
+# Set common variables for the environment. This is automatically pulled in in the root terragrunt.hcl configuration to
+# feed forward to the child modules.
+locals {
+  environment = "stage"
+  atlantis_workflow = "workflowSpecifiedInParent"
+}

--- a/test_examples/project_hcl_with_atlantis_locals/non-prod/us-east-1/stage/mysql/terragrunt.hcl
+++ b/test_examples/project_hcl_with_atlantis_locals/non-prod/us-east-1/stage/mysql/terragrunt.hcl
@@ -1,0 +1,30 @@
+locals {
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+
+  # Extract out common variables for reuse
+  env = local.environment_vars.locals.environment
+}
+
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+terraform {
+  source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//mysql?ref=v0.3.0"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+inputs = {
+  name           = "mysql_${local.env}"
+  instance_class = "db.t2.micro"
+
+  allocated_storage = 20
+  storage_type      = "standard"
+
+  master_username = "admin"
+  # TODO: To avoid storing your DB password in the code, set it as the environment variable TF_VAR_master_password
+}

--- a/test_examples/project_hcl_with_atlantis_locals/non-prod/us-east-1/stage/webserver-cluster/terragrunt.hcl
+++ b/test_examples/project_hcl_with_atlantis_locals/non-prod/us-east-1/stage/webserver-cluster/terragrunt.hcl
@@ -1,0 +1,30 @@
+locals {
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+
+  # Extract out common variables for reuse
+  env = local.environment_vars.locals.environment
+}
+
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+terraform {
+  source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//asg-elb-service?ref=v0.3.0"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+inputs = {
+  name          = "webserver-example-${local.env}"
+  instance_type = "t2.micro"
+
+  min_size = 2
+  max_size = 2
+
+  server_port = 8080
+  elb_port    = 80
+}

--- a/test_examples/project_hcl_with_atlantis_locals/terragrunt.hcl
+++ b/test_examples/project_hcl_with_atlantis_locals/terragrunt.hcl
@@ -1,0 +1,72 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# Terragrunt is a thin wrapper for Terraform that provides extra tools for working with multiple Terraform modules,
+# remote state, and locking: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  extra_atlantis_dependencies = [
+    find_in_parent_folders("account.hcl"),
+    find_in_parent_folders("region.hcl"),
+    find_in_parent_folders("env.hcl"),
+  ]
+
+  # Automatically load account-level variables
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+
+  # Automatically load region-level variables
+  region_vars = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+
+  # Extract the variables we need for easy access
+  account_name = local.account_vars.locals.account_name
+  account_id   = local.account_vars.locals.aws_account_id
+  aws_region   = local.region_vars.locals.aws_region
+}
+
+# Generate an AWS provider block
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "aws" {
+  region = "${local.aws_region}"
+
+  # Only these AWS Account IDs may be operated on by this template
+  allowed_account_ids = ["${local.account_id}"]
+}
+EOF
+}
+
+# Configure Terragrunt to automatically store tfstate files in an S3 bucket
+remote_state {
+  backend = "s3"
+  config = {
+    encrypt        = true
+    bucket         = "${get_env("TG_BUCKET_PREFIX", "")}terragrunt-example-terraform-state-${local.account_name}-${local.aws_region}"
+    key            = "${path_relative_to_include()}/terraform.tfstate"
+    region         = local.aws_region
+    dynamodb_table = "terraform-locks"
+  }
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+}
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# GLOBAL PARAMETERS
+# These variables apply to all configurations in this subfolder. These are automatically merged into the child
+# `terragrunt.hcl` config via the include block.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# Configure root level variables that all resources can inherit. This is especially helpful with multi-account configs
+# where terraform_remote_state data sources are placed directly into the modules.
+inputs = merge(
+  local.account_vars.locals,
+  local.region_vars.locals,
+  local.environment_vars.locals,
+)

--- a/test_examples/project_hcl_with_project_marker/non-prod/account.hcl
+++ b/test_examples/project_hcl_with_project_marker/non-prod/account.hcl
@@ -1,0 +1,7 @@
+# Set account-wide variables. These are automatically pulled in to configure the remote state bucket in the root
+# terragrunt.hcl configuration.
+locals {
+  account_name   = "non-prod"
+  aws_account_id = "replaceme" # TODO: replace me with your AWS account ID!
+  aws_profile    = "non-prod"
+}

--- a/test_examples/project_hcl_with_project_marker/non-prod/arbitrary.hcl
+++ b/test_examples/project_hcl_with_project_marker/non-prod/arbitrary.hcl
@@ -1,0 +1,3 @@
+locals {
+  some = "stuff"
+}

--- a/test_examples/project_hcl_with_project_marker/non-prod/us-east-1/qa/env.hcl
+++ b/test_examples/project_hcl_with_project_marker/non-prod/us-east-1/qa/env.hcl
@@ -1,0 +1,11 @@
+# Set common variables for the environment. This is automatically pulled in in the root terragrunt.hcl configuration to
+# feed forward to the child modules.
+locals {
+  environment = "qa"
+  extra_atlantis_dependencies = [
+    find_in_parent_folders("arbitrary.hcl"),
+    "${dirname(find_in_parent_folders("account.hcl"))}/us-east-1/stage/**/*.hcl",
+  ]
+  atlantis_workflow = "anotherWorkflowSpecifiedInParent"
+    atlantis_project = true
+}

--- a/test_examples/project_hcl_with_project_marker/non-prod/us-east-1/qa/mysql/terragrunt.hcl
+++ b/test_examples/project_hcl_with_project_marker/non-prod/us-east-1/qa/mysql/terragrunt.hcl
@@ -1,0 +1,31 @@
+locals {
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+
+  # Extract out common variables for reuse
+  env = local.environment_vars.locals.environment
+}
+
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+terraform {
+  source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//mysql?ref=v0.3.0"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+inputs = {
+  name           = "mysql_${local.env}"
+  instance_class = "db.t2.micro"
+
+  allocated_storage = 20
+  storage_type      = "standard"
+
+  master_username = "admin"
+  # TODO: To avoid storing your DB password in the code, set it as the environment variable TF_VAR_master_password
+}
+

--- a/test_examples/project_hcl_with_project_marker/non-prod/us-east-1/qa/webserver-cluster/terragrunt.hcl
+++ b/test_examples/project_hcl_with_project_marker/non-prod/us-east-1/qa/webserver-cluster/terragrunt.hcl
@@ -1,0 +1,30 @@
+locals {
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+
+  # Extract out common variables for reuse
+  env = local.environment_vars.locals.environment
+}
+
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+terraform {
+  source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//asg-elb-service?ref=v0.3.0"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+inputs = {
+  name          = "webserver-example-${local.env}"
+  instance_type = "t2.micro"
+
+  min_size = 2
+  max_size = 2
+
+  server_port = 8080
+  elb_port    = 80
+}

--- a/test_examples/project_hcl_with_project_marker/non-prod/us-east-1/region.hcl
+++ b/test_examples/project_hcl_with_project_marker/non-prod/us-east-1/region.hcl
@@ -1,0 +1,5 @@
+# Set common variables for the region. This is automatically pulled in in the root terragrunt.hcl configuration to
+# configure the remote state bucket and pass forward to the child modules as inputs.
+locals {
+  aws_region = "us-east-1"
+}

--- a/test_examples/project_hcl_with_project_marker/non-prod/us-east-1/stage/env.hcl
+++ b/test_examples/project_hcl_with_project_marker/non-prod/us-east-1/stage/env.hcl
@@ -1,0 +1,6 @@
+# Set common variables for the environment. This is automatically pulled in in the root terragrunt.hcl configuration to
+# feed forward to the child modules.
+locals {
+  environment = "stage"
+  atlantis_workflow = "workflowSpecifiedInParent"
+}

--- a/test_examples/project_hcl_with_project_marker/non-prod/us-east-1/stage/mysql/terragrunt.hcl
+++ b/test_examples/project_hcl_with_project_marker/non-prod/us-east-1/stage/mysql/terragrunt.hcl
@@ -1,0 +1,30 @@
+locals {
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+
+  # Extract out common variables for reuse
+  env = local.environment_vars.locals.environment
+}
+
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+terraform {
+  source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//mysql?ref=v0.3.0"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+inputs = {
+  name           = "mysql_${local.env}"
+  instance_class = "db.t2.micro"
+
+  allocated_storage = 20
+  storage_type      = "standard"
+
+  master_username = "admin"
+  # TODO: To avoid storing your DB password in the code, set it as the environment variable TF_VAR_master_password
+}

--- a/test_examples/project_hcl_with_project_marker/non-prod/us-east-1/stage/webserver-cluster/terragrunt.hcl
+++ b/test_examples/project_hcl_with_project_marker/non-prod/us-east-1/stage/webserver-cluster/terragrunt.hcl
@@ -1,0 +1,30 @@
+locals {
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+
+  # Extract out common variables for reuse
+  env = local.environment_vars.locals.environment
+}
+
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+terraform {
+  source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//asg-elb-service?ref=v0.3.0"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+inputs = {
+  name          = "webserver-example-${local.env}"
+  instance_type = "t2.micro"
+
+  min_size = 2
+  max_size = 2
+
+  server_port = 8080
+  elb_port    = 80
+}

--- a/test_examples/project_hcl_with_project_marker/terragrunt.hcl
+++ b/test_examples/project_hcl_with_project_marker/terragrunt.hcl
@@ -1,0 +1,72 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# Terragrunt is a thin wrapper for Terraform that provides extra tools for working with multiple Terraform modules,
+# remote state, and locking: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  extra_atlantis_dependencies = [
+    find_in_parent_folders("account.hcl"),
+    find_in_parent_folders("region.hcl"),
+    find_in_parent_folders("env.hcl"),
+  ]
+
+  # Automatically load account-level variables
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+
+  # Automatically load region-level variables
+  region_vars = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+
+  # Extract the variables we need for easy access
+  account_name = local.account_vars.locals.account_name
+  account_id   = local.account_vars.locals.aws_account_id
+  aws_region   = local.region_vars.locals.aws_region
+}
+
+# Generate an AWS provider block
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "aws" {
+  region = "${local.aws_region}"
+
+  # Only these AWS Account IDs may be operated on by this template
+  allowed_account_ids = ["${local.account_id}"]
+}
+EOF
+}
+
+# Configure Terragrunt to automatically store tfstate files in an S3 bucket
+remote_state {
+  backend = "s3"
+  config = {
+    encrypt        = true
+    bucket         = "${get_env("TG_BUCKET_PREFIX", "")}terragrunt-example-terraform-state-${local.account_name}-${local.aws_region}"
+    key            = "${path_relative_to_include()}/terraform.tfstate"
+    region         = local.aws_region
+    dynamodb_table = "terraform-locks"
+  }
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+}
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# GLOBAL PARAMETERS
+# These variables apply to all configurations in this subfolder. These are automatically merged into the child
+# `terragrunt.hcl` config via the include block.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# Configure root level variables that all resources can inherit. This is especially helpful with multi-account configs
+# where terraform_remote_state data sources are placed directly into the modules.
+inputs = merge(
+  local.account_vars.locals,
+  local.region_vars.locals,
+  local.environment_vars.locals,
+)


### PR DESCRIPTION
# Pull Request

## Related Github Issues

#151 #153

## Description

Added the feature to define arbitrary HCL files as marker for generated atlantis projects. This should allow to implement terragrunt run-all workflows with sane module dependency resolving in Atlantis. Also added support for Atlantis config parameters in the project hcl files. 

Added a few tests, and modified the test for no existing terragrunt.hcl, since the way the root is parsed significantly changed.

## Known issues
Filters are not working properly with project hcl files. Probably filters can also be implemented in the new workDirs loop

## System Availability

lets hope nothing breaks^^
