### PR TITLE
Check for all possible remote source methods

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -170,8 +170,14 @@ func getDependencies(path string, terragruntOptions *options.TerragruntOptions) 
 				return nil, err
 			}
 
-			// If the normalized source begins with `file:///` it is a local path
-			if strings.HasPrefix(parsedSource, "file://") {
+			// Check if the path begins with a drive letter, denoting Windows
+			isWindowsPath, err := regexp.MatchString(`^[A-Z]:`, parsedSource)
+			if err != nil {
+				return nil, err
+			}
+
+			// If the normalized source begins with `file://`, or matched the Windows drive letter check, it is a local path
+			if strings.HasPrefix(parsedSource, "file://") || isWindowsPath {
 				dependencies = append(dependencies, filepath.Join(*source, "*.tf*"))
 
 				var dir string

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -170,23 +170,17 @@ func getDependencies(path string, terragruntOptions *options.TerragruntOptions) 
 				return nil, err
 			}
 
-			// Check if the normalized source matches a pattern of remote sources
-			var isRemoteSource bool
-			isRemoteSource, err := regexp.MatchString(`^(https?|tfr|git|hg|s3|gcs)\:`, parsedSource)
-			if err != nil {
-				return nil, err
-			}
-
-			if !isRemoteSource {
+			// If the normalized source begins with `file:///` it is a local path
+			if strings.HasPrefix(parsedSource, "file:///") {
 				dependencies = append(dependencies, filepath.Join(*source, "*.tf*"))
 
 				var dir string
-
 				if filepath.IsAbs(*source) {
 					dir = *source
 				} else {
 					dir = util.JoinPath(filepath.Dir(path), *source)
 				}
+
 				ls, err := parseTerraformLocalModuleSource(dir)
 				if err != nil {
 					return nil, err

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -171,7 +171,7 @@ func getDependencies(path string, terragruntOptions *options.TerragruntOptions) 
 			}
 
 			// If the normalized source begins with `file:///` it is a local path
-			if strings.HasPrefix(parsedSource, "file:///") {
+			if strings.HasPrefix(parsedSource, "file://") {
 				dependencies = append(dependencies, filepath.Join(*source, "*.tf*"))
 
 				var dir string

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -429,10 +429,87 @@ func TestMultipleIncludes(t *testing.T) {
 	})
 }
 
-func TestTerraformRegistryModule(t *testing.T) {
+func TestRemoteModuleSourceBitbucket(t *testing.T) {
 	runTest(t, filepath.Join("golden", "basic.yaml"), []string{
 		"--root",
-		filepath.Join("..", "test_examples", "terraform_registry_module_source"),
+		filepath.Join("..", "test_examples", "remote_module_source_bitbucket"),
+	})
+}
+
+func TestRemoteModuleSourceGCS(t *testing.T) {
+	runTest(t, filepath.Join("golden", "basic.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "remote_module_source_gcs"),
+	})
+}
+
+func TestRemoteModuleSourceGitHTTPS(t *testing.T) {
+	runTest(t, filepath.Join("golden", "basic.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "remote_module_source_git_https"),
+	})
+}
+
+func TestRemoteModuleSourceGitSCPLike(t *testing.T) {
+	runTest(t, filepath.Join("golden", "basic.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "remote_module_source_git_scp_like"),
+	})
+}
+
+func TestRemoteModuleSourceGitSSH(t *testing.T) {
+	runTest(t, filepath.Join("golden", "basic.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "remote_module_source_git_ssh"),
+	})
+}
+
+func TestRemoteModuleSourceGithubHTTPS(t *testing.T) {
+	runTest(t, filepath.Join("golden", "basic.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "remote_module_source_github_https"),
+	})
+}
+
+func TestRemoteModuleSourceGithubSSH(t *testing.T) {
+	runTest(t, filepath.Join("golden", "basic.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "remote_module_source_github_ssh"),
+	})
+}
+
+func TestRemoteModuleSourceHTTP(t *testing.T) {
+	runTest(t, filepath.Join("golden", "basic.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "remote_module_source_http"),
+	})
+}
+
+func TestRemoteModuleSourceHTTPS(t *testing.T) {
+	runTest(t, filepath.Join("golden", "basic.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "remote_module_source_https"),
+	})
+}
+
+func TestRemoteModuleSourceMercurial(t *testing.T) {
+	runTest(t, filepath.Join("golden", "basic.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "remote_module_source_mercurial"),
+	})
+}
+
+func TestRemoteModuleSourceS3(t *testing.T) {
+	runTest(t, filepath.Join("golden", "basic.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "remote_module_source_s3"),
+	})
+}
+
+func TestRemoteModuleSourceTerraformRegistry(t *testing.T) {
+	runTest(t, filepath.Join("golden", "basic.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "remote_module_source_terraform_registry"),
 	})
 }
 

--- a/cmd/golden/envhcl_allchilds.yaml
+++ b/cmd/golden/envhcl_allchilds.yaml
@@ -509,13 +509,79 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
-  dir: skip/skip_false
+  dir: remote_module_source_bitbucket
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
-  dir: terraform_registry_module_source
+  dir: remote_module_source_gcs
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: remote_module_source_git_https
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: remote_module_source_git_scp_like
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: remote_module_source_git_ssh
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: remote_module_source_github_https
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: remote_module_source_github_ssh
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: remote_module_source_http
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: remote_module_source_https
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: remote_module_source_mercurial
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: remote_module_source_s3
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: remote_module_source_terraform_registry
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: skip/skip_false
 - autoplan:
     enabled: false
     when_modified:

--- a/cmd/golden/envhcl_externalchilds.yaml
+++ b/cmd/golden/envhcl_externalchilds.yaml
@@ -370,13 +370,79 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
-  dir: skip/skip_false
+  dir: remote_module_source_bitbucket
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
-  dir: terraform_registry_module_source
+  dir: remote_module_source_gcs
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: remote_module_source_git_https
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: remote_module_source_git_scp_like
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: remote_module_source_git_ssh
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: remote_module_source_github_https
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: remote_module_source_github_ssh
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: remote_module_source_http
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: remote_module_source_https
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: remote_module_source_mercurial
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: remote_module_source_s3
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: remote_module_source_terraform_registry
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: skip/skip_false
 - autoplan:
     enabled: false
     when_modified:

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-errors/errors v1.1.1 // indirect
 	github.com/gruntwork-io/terragrunt v0.32.2
-	github.com/hashicorp/go-getter v1.5.9 // indirect
+	github.com/hashicorp/go-getter v1.5.9
 	github.com/hashicorp/hcl/v2 v2.10.0
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20210625153042-09f34846faab
 	github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c // indirect

--- a/test_examples/remote_module_source_bitbucket/terragrunt.hcl
+++ b/test_examples/remote_module_source_bitbucket/terragrunt.hcl
@@ -1,0 +1,8 @@
+# https://www.terraform.io/docs/language/modules/sources.html#bitbucket
+terraform {
+  source = "bitbucket.org/hashicorp/tf-test-git"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/remote_module_source_gcs/terragrunt.hcl
+++ b/test_examples/remote_module_source_gcs/terragrunt.hcl
@@ -1,0 +1,8 @@
+# https://www.terraform.io/docs/language/modules/sources.html#gcs-bucket
+terraform {
+  source = "gcs::https://www.googleapis.com/storage/v1/modules/foomodule.zip"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/remote_module_source_git_https/terragrunt.hcl
+++ b/test_examples/remote_module_source_git_https/terragrunt.hcl
@@ -1,0 +1,8 @@
+# https://www.terraform.io/docs/language/modules/sources.html#generic-git-repository
+terraform {
+  source = "git::https://example.com/vpc.git"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/remote_module_source_git_scp_like/terragrunt.hcl
+++ b/test_examples/remote_module_source_git_scp_like/terragrunt.hcl
@@ -1,0 +1,8 @@
+# https://www.terraform.io/docs/language/modules/sources.html#quot-scp-like-quot-address-syntax
+terraform {
+  source = "git::username@example.com:storage.git"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/remote_module_source_git_scp_like/terragrunt.hcl
+++ b/test_examples/remote_module_source_git_scp_like/terragrunt.hcl
@@ -1,6 +1,6 @@
 # https://www.terraform.io/docs/language/modules/sources.html#quot-scp-like-quot-address-syntax
 terraform {
-  source = "git::username@example.com:storage.git"
+  source = "git::git@example.com:storage.git"
 }
 
 inputs = {

--- a/test_examples/remote_module_source_git_ssh/terragrunt.hcl
+++ b/test_examples/remote_module_source_git_ssh/terragrunt.hcl
@@ -1,0 +1,8 @@
+# https://www.terraform.io/docs/language/modules/sources.html#generic-git-repository
+terraform {
+  source = "git::ssh://username@example.com/storage.git"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/remote_module_source_github_https/terragrunt.hcl
+++ b/test_examples/remote_module_source_github_https/terragrunt.hcl
@@ -1,0 +1,8 @@
+# https://www.terraform.io/docs/language/modules/sources.html#github
+terraform {
+  source = "github.com/hashicorp/example"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/remote_module_source_github_ssh/terragrunt.hcl
+++ b/test_examples/remote_module_source_github_ssh/terragrunt.hcl
@@ -1,0 +1,8 @@
+# https://www.terraform.io/docs/language/modules/sources.html#github
+terraform {
+  source = "git@github.com:hashicorp/example.git"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/remote_module_source_http/terragrunt.hcl
+++ b/test_examples/remote_module_source_http/terragrunt.hcl
@@ -1,0 +1,8 @@
+# https://www.terraform.io/docs/language/modules/sources.html#http-urls
+terraform {
+  source = "http://example.com/vpc-module.zip"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/remote_module_source_https/terragrunt.hcl
+++ b/test_examples/remote_module_source_https/terragrunt.hcl
@@ -1,0 +1,8 @@
+# https://www.terraform.io/docs/language/modules/sources.html#http-urls
+terraform {
+  source = "https://example.com/vpc-module.zip"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/remote_module_source_mercurial/terragrunt.hcl
+++ b/test_examples/remote_module_source_mercurial/terragrunt.hcl
@@ -1,0 +1,8 @@
+# https://www.terraform.io/docs/language/modules/sources.html#http-urls
+terraform {
+  source = "hg::http://example.com/vpc.hg"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/remote_module_source_s3/terragrunt.hcl
+++ b/test_examples/remote_module_source_s3/terragrunt.hcl
@@ -1,0 +1,8 @@
+# https://www.terraform.io/docs/language/modules/sources.html#s3-bucket
+terraform {
+  source = "s3::https://s3-eu-west-1.amazonaws.com/examplecorp-terraform-modules/vpc.zip"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/remote_module_source_terraform_registry/terragrunt.hcl
+++ b/test_examples/remote_module_source_terraform_registry/terragrunt.hcl
@@ -1,3 +1,4 @@
+# https://www.terraform.io/docs/language/modules/sources.html#terraform-registry
 terraform {
   source = "tfr:///terraform-aws-modules/vpc/aws?version=3.7.0"
 }


### PR DESCRIPTION
# Pull Request

## Related Github Issues
- #172 

## Description

Refactor the remote module source path check to encompass all possible types. Use [go-getter](https://github.com/hashicorp/go-getter) to detect the source path, which normalizes the string into a format that can be checked by regex to cover any remote protocol prefix. This helps ensure we support the same source methods that Terraform (and by extension, Terragrunt) do.

Expand the test suite to cover all source methods as documented in the [Terraform docs](https://www.terraform.io/docs/language/modules/sources.html).

## Security Implications

- _[none]_

## System Availability

- _[none]_
