### PR TITLE
feat: support get_original_terragrunt_dir

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -236,6 +236,7 @@ func getDependencies(path string, terragruntOptions *options.TerragruntOptions) 
 
 			depPath := dep
 			terrOpts, _ := options.NewTerragruntOptions(depPath)
+			terrOpts.OriginalTerragruntConfigPath = terragruntOptions.OriginalTerragruntConfigPath
 			childDeps, err := getDependencies(depPath, terrOpts)
 			if err != nil {
 				continue
@@ -298,6 +299,7 @@ func createProject(sourcePath string) (*AtlantisProject, error) {
 	if err != nil {
 		return nil, err
 	}
+	options.OriginalTerragruntConfigPath = sourcePath
 	options.RunTerragrunt = cli.RunTerragrunt
 	options.Env = getEnvs()
 

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -561,3 +561,10 @@ func TestEnvHCLProjectMarker(t *testing.T) {
 		"--use-project-markers=true",
 	})
 }
+
+func TestWithOriginalDir(t *testing.T) {
+	runTest(t, filepath.Join("golden", "withOriginalDir.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "with_original_dir"),
+	})
+}

--- a/cmd/golden/envhcl_allchilds.yaml
+++ b/cmd/golden/envhcl_allchilds.yaml
@@ -704,5 +704,19 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../common/terragrunt.hcl
+    - ../dependency/terragrunt.hcl
+  dir: with_original_dir/child
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: with_original_dir/dependency
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
   dir: with_parent/child
 version: 3

--- a/cmd/golden/envhcl_externalchilds.yaml
+++ b/cmd/golden/envhcl_externalchilds.yaml
@@ -511,5 +511,19 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../common/terragrunt.hcl
+    - ../dependency/terragrunt.hcl
+  dir: with_original_dir/child
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: with_original_dir/dependency
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
   dir: with_parent/child
 version: 3

--- a/cmd/golden/withOriginalDir.yaml
+++ b/cmd/golden/withOriginalDir.yaml
@@ -1,0 +1,19 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../common/terragrunt.hcl
+    - ../dependency/terragrunt.hcl
+  dir: child
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: dependency
+version: 3

--- a/test_examples/with_original_dir/child/terragrunt.hcl
+++ b/test_examples/with_original_dir/child/terragrunt.hcl
@@ -1,0 +1,17 @@
+include "root" {
+  path   = find_in_parent_folders()
+  expose = true
+}
+
+include "common_configs" {
+  path   = "${dirname(find_in_parent_folders())}/common/terragrunt.hcl"
+  expose = true
+}
+
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/with_original_dir/common/terragrunt.hcl
+++ b/test_examples/with_original_dir/common/terragrunt.hcl
@@ -1,0 +1,13 @@
+locals {
+  extra_atlantis_dependencies = [
+    "${get_parent_terragrunt_dir()}/terragrunt.hcl"
+  ]
+}
+
+dependency "dependency" {
+  config_path = "${get_original_terragrunt_dir()}/../dependency"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/with_original_dir/dependency/terragrunt.hcl
+++ b/test_examples/with_original_dir/dependency/terragrunt.hcl
@@ -1,0 +1,12 @@
+include "root" {
+  path   = find_in_parent_folders()
+  expose = true
+}
+
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/with_original_dir/terragrunt.hcl
+++ b/test_examples/with_original_dir/terragrunt.hcl
@@ -1,0 +1,3 @@
+locals {
+  ahhhhhh = "pst"
+}


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- #178 

## Description

This is the same functional code as #178 but rebased against current master and with tests added. This was based on the original PR code, so attributions should remain. I ran into a need for this function and found that PR just needing tests, hopefully this helps get this merged. 

  One observation is that in the pattern of using a "common" folder (my use case) the common folder is not automatically pulled in as a dependency. A workaround is to set `extra_atlantis_dependencies` in the common `.hcl` file like this: 
```hcl
locals {
  extra_atlantis_dependencies = [
    "${get_parent_terragrunt_dir()}/terragrunt.hcl"
  ]
}
``` 
This can be seen in `test_examples/with_original_dir/common/terragrunt.hcl`. It may be something specific to how I am using this function, but wanted to call it out.

## Security Implications

- _[none]_

## System Availability

- _[none]_
