### PR TITLE
Bump terragrunt version to v0.35.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.12.1
+VERSION=1.12.2
 PATH_BUILD=build/
 FILE_COMMAND=terragrunt-atlantis-config
 FILE_ARCH=darwin_amd64

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then, make sure `terragrunt-atlantis-config` is present on your Atlantis server.
 
 ```hcl
 variable "terragrunt_atlantis_config_version" {
-  default = "1.12.1"
+  default = "1.12.2"
 }
 
 build {
@@ -189,7 +189,7 @@ You can install this tool locally to checkout what kinds of config it will gener
 Recommended: Install any version via go get:
 
 ```bash
-cd && GO111MODULE=on go get github.com/transcend-io/terragrunt-atlantis-config@v1.12.1 && cd -
+cd && GO111MODULE=on go get github.com/transcend-io/terragrunt-atlantis-config@v1.12.2 && cd -
 ```
 
 This module officially supports golang versions v1.13, v1.14, v1.15, and v1.16, tested on CircleCI with each build

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bmatcuk/doublestar v1.3.1 // indirect
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-errors/errors v1.1.1 // indirect
-	github.com/gruntwork-io/terragrunt v0.32.2
+	github.com/gruntwork-io/terragrunt v0.35.16
 	github.com/hashicorp/go-getter v1.5.9
 	github.com/hashicorp/hcl/v2 v2.10.0
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20210625153042-09f34846faab

--- a/go.sum
+++ b/go.sum
@@ -194,6 +194,8 @@ github.com/aws/aws-sdk-go v1.37.0/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zK
 github.com/aws/aws-sdk-go v1.37.18/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.40.27 h1:8fWW0CpmBZ8WWduNwl4vE9t07nMYFrhAsUHjPj81qUM=
 github.com/aws/aws-sdk-go v1.40.27/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
+github.com/aws/aws-sdk-go v1.41.7 h1:vlpR8Cky3ZxUVNINgeRZS6N0p6zmFvu/ZqRRwrTI25U=
+github.com/aws/aws-sdk-go v1.41.7/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -491,6 +493,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFb
 github.com/gruntwork-io/gruntwork-cli v0.7.0/go.mod h1:jp6Z7NcLF2avpY8v71fBx6hds9eOFPELSuD/VPv7w00=
 github.com/gruntwork-io/terragrunt v0.32.2 h1:lg2VuJ2P/VRJXrt7AxPUqzqliDYdoiIltWPio/gk/5c=
 github.com/gruntwork-io/terragrunt v0.32.2/go.mod h1:zM5OvxSfF0EkdnOA5XvXlVI230BMJZ7H+aY3sX4QyZY=
+github.com/gruntwork-io/terragrunt v0.35.16 h1:5GWp1aEcGgqcdSEcGMdk2gzjGmrZrvLh9rHhV+EtWF8=
+github.com/gruntwork-io/terragrunt v0.35.16/go.mod h1:RrG5599JjmyVx/6AIS1coH6XTj5UOI9BPXZv9ImAfxA=
 github.com/gruntwork-io/terratest v0.32.6 h1:OEA11ZqEwKRowEdxusDnAPnMUN0w/jzeNcziuQsqkYk=
 github.com/gruntwork-io/terratest v0.32.6/go.mod h1:0iy7d56CziX3R4ZUn570HMElr4WgBKoKNa8Hzex7bvo=
 github.com/hashicorp/aws-sdk-go-base v0.6.0/go.mod h1:2fRjWDv3jJBeN6mVWFHV6hFTNeFBx2gpDLQaZNxUVAY=

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import "github.com/transcend-io/terragrunt-atlantis-config/cmd"
 // This variable is set at build time using -ldflags parameters.
 // But we still set a default here for those using plain `go get` downloads
 // For more info, see: http://stackoverflow.com/a/11355611/483528
-var VERSION string = "1.12.1"
+var VERSION string = "1.12.2"
 
 func main() {
 	cmd.Execute(VERSION)


### PR DESCRIPTION
# Pull Request

## Description
This fixes issues where child terragrunt modules would have `include.root.inputs....` in dependency blocks.
With older terragrunt version dependency block parser wasn't able to resolve these fields from includes, resulting in `null` errors.