### PR TITLE
feat: support common modules

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,20 +1,19 @@
-
 name: Build and test code
-on: [ push, pull_request ]
+on: [push, pull_request]
 
 jobs:
   run-tests:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        golang-version: [1.13, 1.14, 1.15, 1.16]
+        golang-version: [1.13, 1.14, 1.15, 1.16, 1.17]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup golang v${{ matrix.golang-version }}
         uses: actions/setup-go@v2
         with:
-          go-version: '^${{ matrix.golang-version }}'
+          go-version: "^${{ matrix.golang-version }}"
       - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -106,15 +106,7 @@ func lookupProjectHcl(m map[string][]string, value string) (key string) {
 	return key
 }
 
-// func stringInSlice(a string, list []string) bool {
-// 	for _, b := range list {
-// 		if b == a {
-// 			return true
-// 		}
-// 	}
-// 	return false
-// }
-
+// sliceUnion takes two slices of strings and produces a union of them, containing only unique values
 func sliceUnion(a, b []string) []string {
 	m := make(map[string]bool)
 
@@ -826,7 +818,6 @@ var autoPlan bool
 var autoMerge bool
 var ignoreParentTerragrunt bool
 var createParentProject bool
-var includeParentChanges bool
 var ignoreDependencyBlocks bool
 var parallel bool
 var createWorkspace bool
@@ -864,7 +855,6 @@ func init() {
 	generateCmd.PersistentFlags().BoolVar(&autoMerge, "automerge", false, "Enable auto merge. Default is disabled")
 	generateCmd.PersistentFlags().BoolVar(&ignoreParentTerragrunt, "ignore-parent-terragrunt", true, "Ignore parent terragrunt configs (those which don't reference a terraform module). Default is enabled")
 	generateCmd.PersistentFlags().BoolVar(&createParentProject, "create-parent-project", false, "Create a project for the parent terragrunt configs (those which don't reference a terraform module). Default is disabled")
-	generateCmd.PersistentFlags().BoolVar(&includeParentChanges, "include-parent-changes", false, "Create a project for the parent terragrunt configs (those which don't reference a terraform module). Default is disabled")
 	generateCmd.PersistentFlags().BoolVar(&ignoreDependencyBlocks, "ignore-dependency-blocks", false, "When true, dependencies found in `dependency` blocks will be ignored")
 	generateCmd.PersistentFlags().BoolVar(&parallel, "parallel", true, "Enables plans and applys to happen in parallel. Default is enabled")
 	generateCmd.PersistentFlags().BoolVar(&createWorkspace, "create-workspace", false, "Use different workspace for each project. Default is use default workspace")

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -138,7 +138,7 @@ func getDependencies(path string, terragruntOptions *options.TerragruntOptions) 
 			getDependenciesCache.set(path, getDependenciesOutput{nil, err})
 			return nil, err
 		}
-		if isParent && !createParentProject && ignoreParentTerragrunt {
+		if isParent && ignoreParentTerragrunt {
 			getDependenciesCache.set(path, getDependenciesOutput{nil, nil})
 			return nil, nil
 		}

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -82,7 +82,7 @@ func runTest(t *testing.T, goldenFile string, args []string) {
 		return
 	}
 
-	assert.Equal(t, content, goldenContents)
+	assert.Equal(t, goldenContents, content)
 }
 
 func TestSettingRoot(t *testing.T) {

--- a/cmd/golden/apply_overrides.yaml
+++ b/cmd/golden/apply_overrides.yaml
@@ -9,6 +9,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: child_that_does_not_override
 - apply_requirements:
   - mergeable
@@ -17,6 +18,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: child_that_overrides
 - apply_requirements: []
   autoplan:
@@ -24,6 +26,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: child_that_overrides_to_empty
 - autoplan:
     enabled: false

--- a/cmd/golden/autoplan.yaml
+++ b/cmd/golden/autoplan.yaml
@@ -7,17 +7,20 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: autoplan_false
 - autoplan:
     enabled: true
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: autoplan_true
 - autoplan:
     enabled: true
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: set_in_parent
 version: 3

--- a/cmd/golden/envhcl_allchilds.yaml
+++ b/cmd/golden/envhcl_allchilds.yaml
@@ -9,6 +9,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: apply_requirements_overrides/child_that_does_not_override
 - apply_requirements:
   - mergeable
@@ -17,6 +18,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: apply_requirements_overrides/child_that_overrides
 - apply_requirements: []
   autoplan:
@@ -24,6 +26,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: apply_requirements_overrides/child_that_overrides_to_empty
 - autoplan:
     enabled: false
@@ -51,18 +54,21 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: autoplan/autoplan_false
 - autoplan:
     enabled: true
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: autoplan/autoplan_true
 - autoplan:
     enabled: true
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: autoplan/set_in_parent
 - autoplan:
     enabled: false
@@ -104,6 +110,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: child_and_parent_specify_workflow/child
   workflow: workflowSpecifiedInChild
 - autoplan:
@@ -131,6 +138,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../terraform.tfvars
     - ../dev.tfvars
     - ../us-east-1.tfvars
@@ -142,12 +150,14 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: extra_arguments/no_files_at_all
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../dev.tfvars
     - ../us-east-1.tfvars
     - dev.tfvars
@@ -158,6 +168,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../terraform.tfvars
   dir: extra_arguments/only_required_files
 - autoplan:
@@ -165,6 +176,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../../../../common_vars/apps/consul/sg.tfvars
     - main.tfvars
   dir: extra_arguments/var_file
@@ -183,18 +195,21 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../terragrunt.hcl
   dir: invalid_parent_module/child
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../terragrunt.hcl
   dir: invalid_parent_module/child/deep
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../root-module/*.tf*
     - ../terraform-module/*.tf*
   dir: local_terraform_abs_module_source/terragrunt-module
@@ -211,6 +226,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../terraform-another-module/*.tf*
     - ../terraform-module/*.tf*
     - ../terraform-module/nested-module/*.tf*
@@ -222,12 +238,14 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
   dir: multi_accounts_vpc_route53_tgw/network-account/eu-west-1/network
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
   dir: multi_accounts_vpc_route53_tgw/network-account/eu-west-1/network/transit-gateway
 - autoplan:
     enabled: false
@@ -236,6 +254,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../env-a/network/vpc/terragrunt.hcl
     - ../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
   dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/_global
@@ -244,6 +263,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../../terragrunt.hcl
     - ../../../env-a/network/vpc/terragrunt.hcl
     - ../../../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
   dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/_global/route53/test-zone
@@ -254,6 +274,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
   dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/env-a
 - autoplan:
@@ -261,6 +282,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../../terragrunt.hcl
     - ../../../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
   dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/env-a/network/vpc
 - autoplan:
@@ -268,6 +290,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../use_terraform_12_parent.hcl
+    - ../use_terraform_13_parent.hcl
   dir: multiple_includes/includes_tf_12_then_13
   terraform_version: 0.13.9001
 - autoplan:
@@ -275,6 +299,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../use_terraform_13_parent.hcl
+    - ../use_terraform_12_parent.hcl
   dir: multiple_includes/includes_tf_13_then_12
   terraform_version: 0.12.9001
 - autoplan:
@@ -282,6 +308,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../use_terraform_12_parent.hcl
   dir: multiple_includes/uses_terraform_12
   terraform_version: 0.12.9001
 - autoplan:
@@ -289,6 +316,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../use_terraform_13_parent.hcl
   dir: multiple_includes/uses_terraform_13
   terraform_version: 0.13.9001
 - autoplan:
@@ -298,6 +326,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../stage/network/terragrunt.hcl
   dir: no_terraform_blocks/myproject/eu-south-1/infra
 - autoplan:
@@ -305,6 +334,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../network/terragrunt.hcl
     - ../../stage/network/terragrunt.hcl
   dir: no_terraform_blocks/myproject/eu-south-1/infra/apps
@@ -313,6 +343,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../../stage/network/terragrunt.hcl
   dir: no_terraform_blocks/myproject/eu-south-1/infra/network
 - autoplan:
@@ -322,12 +353,14 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
   dir: no_terraform_blocks/myproject/eu-south-1/stage
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../network/terragrunt.hcl
   dir: no_terraform_blocks/myproject/eu-south-1/stage/dbs
 - autoplan:
@@ -335,6 +368,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
   dir: no_terraform_blocks/myproject/eu-south-1/stage/network
 - autoplan:
     enabled: false
@@ -343,24 +377,28 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../terragrunt.hcl
   dir: no_terraform_blocks/myproject/global
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../terragrunt.hcl
   dir: no_terraform_blocks/myproject/global/dns
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../terragrunt.hcl
   dir: no_terraform_blocks/myproject/global/iam
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../parent/terragrunt.hcl
     - some_parent_dep
     - ../file_in_parent_of_child.json
     - ../../parent/folder_under_parent/common_tags.hcl
@@ -371,6 +409,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../parent/terragrunt.hcl
     - some_parent_dep
     - local_tags.yaml
     - ../file_in_parent_of_child.json
@@ -382,6 +421,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: parent_with_workflow_local/child
   workflow: workflowSpecifiedInParent
 - autoplan:
@@ -391,6 +431,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../account.hcl
     - ../region.hcl
     - ../../arbitrary.hcl
@@ -402,6 +443,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -411,6 +453,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -422,6 +465,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../account.hcl
     - ../region.hcl
   dir: project_hcl_with_atlantis_locals/non-prod/us-east-1/stage
@@ -431,6 +475,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -440,6 +485,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -451,6 +497,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../account.hcl
     - ../region.hcl
     - ../../arbitrary.hcl
@@ -462,6 +509,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -471,6 +519,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -482,6 +531,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../account.hcl
     - ../region.hcl
   dir: project_hcl_with_project_marker/non-prod/us-east-1/stage
@@ -491,6 +541,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -500,6 +551,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -581,12 +633,14 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: skip/skip_false
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: terraform_version/inherit_from_parent
   terraform_version: 0.12.9001
 - autoplan:
@@ -594,6 +648,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: terraform_version/override_parent
   terraform_version: 0.13.9001
 - autoplan:
@@ -609,14 +664,19 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
+    - ../../../_envcommon/mysql.hcl
     - ../../account.hcl
     - ../region.hcl
+    - ../../../_envcommon/webserver-cluster.hcl
   dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/qa
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/mysql.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -626,6 +686,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/webserver-cluster.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -637,14 +699,19 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
+    - ../../../_envcommon/mysql.hcl
     - ../../account.hcl
     - ../region.hcl
+    - ../../../_envcommon/webserver-cluster.hcl
   dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/stage
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/mysql.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -654,6 +721,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/webserver-cluster.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -665,14 +734,19 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
+    - ../../../_envcommon/mysql.hcl
     - ../../account.hcl
     - ../region.hcl
+    - ../../../_envcommon/webserver-cluster.hcl
   dir: terragrunt-infrastructure-live-example/prod/us-east-1/prod
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/mysql.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -682,6 +756,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/webserver-cluster.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -704,6 +780,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../common/terragrunt.hcl
     - ../dependency/terragrunt.hcl
   dir: with_original_dir/child
@@ -712,11 +789,13 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: with_original_dir/dependency
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: with_parent/child
 version: 3

--- a/cmd/golden/envhcl_externalchilds.yaml
+++ b/cmd/golden/envhcl_externalchilds.yaml
@@ -9,6 +9,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: apply_requirements_overrides/child_that_does_not_override
 - apply_requirements:
   - mergeable
@@ -17,6 +18,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: apply_requirements_overrides/child_that_overrides
 - apply_requirements: []
   autoplan:
@@ -24,6 +26,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: apply_requirements_overrides/child_that_overrides_to_empty
 - autoplan:
     enabled: false
@@ -51,18 +54,21 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: autoplan/autoplan_false
 - autoplan:
     enabled: true
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: autoplan/autoplan_true
 - autoplan:
     enabled: true
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: autoplan/set_in_parent
 - autoplan:
     enabled: false
@@ -104,6 +110,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: child_and_parent_specify_workflow/child
   workflow: workflowSpecifiedInChild
 - autoplan:
@@ -131,6 +138,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../terraform.tfvars
     - ../dev.tfvars
     - ../us-east-1.tfvars
@@ -142,12 +150,14 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: extra_arguments/no_files_at_all
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../dev.tfvars
     - ../us-east-1.tfvars
     - dev.tfvars
@@ -158,6 +168,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../terraform.tfvars
   dir: extra_arguments/only_required_files
 - autoplan:
@@ -165,6 +176,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../../../../common_vars/apps/consul/sg.tfvars
     - main.tfvars
   dir: extra_arguments/var_file
@@ -183,12 +195,14 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../terragrunt.hcl
   dir: invalid_parent_module/child
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../root-module/*.tf*
     - ../terraform-module/*.tf*
   dir: local_terraform_abs_module_source/terragrunt-module
@@ -205,6 +219,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../terraform-another-module/*.tf*
     - ../terraform-module/*.tf*
     - ../terraform-module/nested-module/*.tf*
@@ -216,6 +231,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
   dir: multi_accounts_vpc_route53_tgw/network-account/eu-west-1/network
 - autoplan:
     enabled: false
@@ -224,6 +240,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../env-a/network/vpc/terragrunt.hcl
     - ../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
   dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/_global
@@ -234,6 +251,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
   dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/env-a
 - autoplan:
@@ -241,6 +259,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../use_terraform_12_parent.hcl
+    - ../use_terraform_13_parent.hcl
   dir: multiple_includes/includes_tf_12_then_13
   terraform_version: 0.13.9001
 - autoplan:
@@ -248,6 +268,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../use_terraform_13_parent.hcl
+    - ../use_terraform_12_parent.hcl
   dir: multiple_includes/includes_tf_13_then_12
   terraform_version: 0.12.9001
 - autoplan:
@@ -255,6 +277,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../use_terraform_12_parent.hcl
   dir: multiple_includes/uses_terraform_12
   terraform_version: 0.12.9001
 - autoplan:
@@ -262,6 +285,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../use_terraform_13_parent.hcl
   dir: multiple_includes/uses_terraform_13
   terraform_version: 0.13.9001
 - autoplan:
@@ -271,6 +295,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../stage/network/terragrunt.hcl
   dir: no_terraform_blocks/myproject/eu-south-1/infra
 - autoplan:
@@ -280,6 +305,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
   dir: no_terraform_blocks/myproject/eu-south-1/stage
 - autoplan:
     enabled: false
@@ -288,12 +314,14 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../terragrunt.hcl
   dir: no_terraform_blocks/myproject/global
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../parent/terragrunt.hcl
     - some_parent_dep
     - ../file_in_parent_of_child.json
     - ../../parent/folder_under_parent/common_tags.hcl
@@ -304,6 +332,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../parent/terragrunt.hcl
     - some_parent_dep
     - local_tags.yaml
     - ../file_in_parent_of_child.json
@@ -315,6 +344,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: parent_with_workflow_local/child
   workflow: workflowSpecifiedInParent
 - autoplan:
@@ -324,6 +354,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../account.hcl
     - ../region.hcl
     - ../../arbitrary.hcl
@@ -337,6 +368,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../account.hcl
     - ../region.hcl
   dir: project_hcl_with_atlantis_locals/non-prod/us-east-1/stage
@@ -348,6 +380,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../account.hcl
     - ../region.hcl
     - ../../arbitrary.hcl
@@ -361,6 +394,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../account.hcl
     - ../region.hcl
   dir: project_hcl_with_project_marker/non-prod/us-east-1/stage
@@ -442,12 +476,14 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: skip/skip_false
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: terraform_version/inherit_from_parent
   terraform_version: 0.12.9001
 - autoplan:
@@ -455,6 +491,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: terraform_version/override_parent
   terraform_version: 0.13.9001
 - autoplan:
@@ -470,8 +507,11 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
+    - ../../../_envcommon/mysql.hcl
     - ../../account.hcl
     - ../region.hcl
+    - ../../../_envcommon/webserver-cluster.hcl
   dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/qa
 - autoplan:
     enabled: false
@@ -480,8 +520,11 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
+    - ../../../_envcommon/mysql.hcl
     - ../../account.hcl
     - ../region.hcl
+    - ../../../_envcommon/webserver-cluster.hcl
   dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/stage
 - autoplan:
     enabled: false
@@ -490,8 +533,11 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
+    - ../../../_envcommon/mysql.hcl
     - ../../account.hcl
     - ../region.hcl
+    - ../../../_envcommon/webserver-cluster.hcl
   dir: terragrunt-infrastructure-live-example/prod/us-east-1/prod
 - autoplan:
     enabled: false
@@ -511,6 +557,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../common/terragrunt.hcl
     - ../dependency/terragrunt.hcl
   dir: with_original_dir/child
@@ -519,11 +566,13 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: with_original_dir/dependency
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: with_parent/child
 version: 3

--- a/cmd/golden/envhcl_nochilds.yaml
+++ b/cmd/golden/envhcl_nochilds.yaml
@@ -9,6 +9,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../terragrunt.hcl
   dir: invalid_parent_module/child
 - autoplan:
     enabled: false
@@ -17,6 +18,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
   dir: multi_accounts_vpc_route53_tgw/network-account/eu-west-1/network
 - autoplan:
     enabled: false
@@ -25,6 +27,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../env-a/network/vpc/terragrunt.hcl
     - ../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
   dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/_global
@@ -35,6 +38,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
   dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/env-a
 - autoplan:
@@ -44,6 +48,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../stage/network/terragrunt.hcl
   dir: no_terraform_blocks/myproject/eu-south-1/infra
 - autoplan:
@@ -53,6 +58,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
   dir: no_terraform_blocks/myproject/eu-south-1/stage
 - autoplan:
     enabled: false
@@ -61,6 +67,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../terragrunt.hcl
   dir: no_terraform_blocks/myproject/global
 - autoplan:
     enabled: false
@@ -69,6 +76,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../account.hcl
     - ../region.hcl
     - ../../arbitrary.hcl
@@ -82,6 +90,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../account.hcl
     - ../region.hcl
   dir: project_hcl_with_atlantis_locals/non-prod/us-east-1/stage
@@ -93,6 +102,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../account.hcl
     - ../region.hcl
     - ../../arbitrary.hcl
@@ -106,6 +116,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../account.hcl
     - ../region.hcl
   dir: project_hcl_with_project_marker/non-prod/us-east-1/stage
@@ -117,8 +128,11 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
+    - ../../../_envcommon/mysql.hcl
     - ../../account.hcl
     - ../region.hcl
+    - ../../../_envcommon/webserver-cluster.hcl
   dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/qa
 - autoplan:
     enabled: false
@@ -127,8 +141,11 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
+    - ../../../_envcommon/mysql.hcl
     - ../../account.hcl
     - ../region.hcl
+    - ../../../_envcommon/webserver-cluster.hcl
   dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/stage
 - autoplan:
     enabled: false
@@ -137,7 +154,10 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
+    - ../../../_envcommon/mysql.hcl
     - ../../account.hcl
     - ../region.hcl
+    - ../../../_envcommon/webserver-cluster.hcl
   dir: terragrunt-infrastructure-live-example/prod/us-east-1/prod
 version: 3

--- a/cmd/golden/envhcl_subchilds.yaml
+++ b/cmd/golden/envhcl_subchilds.yaml
@@ -9,12 +9,14 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../terragrunt.hcl
   dir: invalid_parent_module/child
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../terragrunt.hcl
   dir: invalid_parent_module/child/deep
 - autoplan:
     enabled: false
@@ -23,12 +25,14 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
   dir: multi_accounts_vpc_route53_tgw/network-account/eu-west-1/network
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
   dir: multi_accounts_vpc_route53_tgw/network-account/eu-west-1/network/transit-gateway
 - autoplan:
     enabled: false
@@ -37,6 +41,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../env-a/network/vpc/terragrunt.hcl
     - ../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
   dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/_global
@@ -45,6 +50,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../../terragrunt.hcl
     - ../../../env-a/network/vpc/terragrunt.hcl
     - ../../../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
   dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/_global/route53/test-zone
@@ -55,6 +61,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
   dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/env-a
 - autoplan:
@@ -62,6 +69,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../../terragrunt.hcl
     - ../../../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
   dir: multi_accounts_vpc_route53_tgw/prod/eu-west-1/env-a/network/vpc
 - autoplan:
@@ -71,6 +79,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../stage/network/terragrunt.hcl
   dir: no_terraform_blocks/myproject/eu-south-1/infra
 - autoplan:
@@ -78,6 +87,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../network/terragrunt.hcl
     - ../../stage/network/terragrunt.hcl
   dir: no_terraform_blocks/myproject/eu-south-1/infra/apps
@@ -86,6 +96,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../../stage/network/terragrunt.hcl
   dir: no_terraform_blocks/myproject/eu-south-1/infra/network
 - autoplan:
@@ -95,12 +106,14 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
   dir: no_terraform_blocks/myproject/eu-south-1/stage
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../network/terragrunt.hcl
   dir: no_terraform_blocks/myproject/eu-south-1/stage/dbs
 - autoplan:
@@ -108,6 +121,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
   dir: no_terraform_blocks/myproject/eu-south-1/stage/network
 - autoplan:
     enabled: false
@@ -116,18 +130,21 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../terragrunt.hcl
   dir: no_terraform_blocks/myproject/global
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../terragrunt.hcl
   dir: no_terraform_blocks/myproject/global/dns
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../terragrunt.hcl
   dir: no_terraform_blocks/myproject/global/iam
 - autoplan:
     enabled: false
@@ -136,6 +153,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../account.hcl
     - ../region.hcl
     - ../../arbitrary.hcl
@@ -147,6 +165,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -156,6 +175,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -167,6 +187,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../account.hcl
     - ../region.hcl
   dir: project_hcl_with_atlantis_locals/non-prod/us-east-1/stage
@@ -176,6 +197,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -185,6 +207,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -196,6 +219,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../account.hcl
     - ../region.hcl
     - ../../arbitrary.hcl
@@ -207,6 +231,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -216,6 +241,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -227,6 +253,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../account.hcl
     - ../region.hcl
   dir: project_hcl_with_project_marker/non-prod/us-east-1/stage
@@ -236,6 +263,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -245,6 +273,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -256,14 +285,19 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
+    - ../../../_envcommon/mysql.hcl
     - ../../account.hcl
     - ../region.hcl
+    - ../../../_envcommon/webserver-cluster.hcl
   dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/qa
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/mysql.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -273,6 +307,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/webserver-cluster.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -284,14 +320,19 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
+    - ../../../_envcommon/mysql.hcl
     - ../../account.hcl
     - ../region.hcl
+    - ../../../_envcommon/webserver-cluster.hcl
   dir: terragrunt-infrastructure-live-example/non-prod/us-east-1/stage
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/mysql.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -301,6 +342,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/webserver-cluster.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -312,14 +355,19 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
+    - ../../../_envcommon/mysql.hcl
     - ../../account.hcl
     - ../region.hcl
+    - ../../../_envcommon/webserver-cluster.hcl
   dir: terragrunt-infrastructure-live-example/prod/us-east-1/prod
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/mysql.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -329,6 +377,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/webserver-cluster.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl

--- a/cmd/golden/extraArguments.yaml
+++ b/cmd/golden/extraArguments.yaml
@@ -7,6 +7,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../terraform.tfvars
     - ../dev.tfvars
     - ../us-east-1.tfvars
@@ -18,12 +19,14 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: no_files_at_all
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../dev.tfvars
     - ../us-east-1.tfvars
     - dev.tfvars
@@ -34,6 +37,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../terraform.tfvars
   dir: only_required_files
 - autoplan:
@@ -41,6 +45,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../../../../common_vars/apps/consul/sg.tfvars
     - main.tfvars
   dir: var_file

--- a/cmd/golden/filterGlobInfraLiveMySQL.yaml
+++ b/cmd/golden/filterGlobInfraLiveMySQL.yaml
@@ -7,6 +7,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/mysql.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -16,6 +18,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/mysql.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -25,6 +29,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/mysql.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl

--- a/cmd/golden/filterInfraLiveNonProd.yaml
+++ b/cmd/golden/filterInfraLiveNonProd.yaml
@@ -7,6 +7,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/mysql.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -16,6 +18,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/webserver-cluster.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -25,6 +29,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/mysql.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -34,6 +40,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/webserver-cluster.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl

--- a/cmd/golden/filterInfraLiveProd.yaml
+++ b/cmd/golden/filterInfraLiveProd.yaml
@@ -7,6 +7,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/mysql.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -16,6 +18,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/webserver-cluster.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl

--- a/cmd/golden/infrastructureLive.yaml
+++ b/cmd/golden/infrastructureLive.yaml
@@ -7,6 +7,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/mysql.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -16,6 +18,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/webserver-cluster.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -25,6 +29,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/mysql.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -34,6 +40,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/webserver-cluster.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -43,6 +51,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/mysql.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl
@@ -52,6 +62,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
+    - ../../../../_envcommon/webserver-cluster.hcl
     - ../../../account.hcl
     - ../../region.hcl
     - ../env.hcl

--- a/cmd/golden/invalid_parent_module.yaml
+++ b/cmd/golden/invalid_parent_module.yaml
@@ -7,5 +7,6 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../terragrunt.hcl
   dir: child/deep
 version: 3

--- a/cmd/golden/local_terraform_abs_module.yaml
+++ b/cmd/golden/local_terraform_abs_module.yaml
@@ -7,6 +7,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../root-module/*.tf*
     - ../terraform-module/*.tf*
   dir: terragrunt-module

--- a/cmd/golden/local_tf_module.yaml
+++ b/cmd/golden/local_tf_module.yaml
@@ -7,6 +7,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../terraform-another-module/*.tf*
     - ../terraform-module/*.tf*
     - ../terraform-module/nested-module/*.tf*

--- a/cmd/golden/mergeParentDependencies.yaml
+++ b/cmd/golden/mergeParentDependencies.yaml
@@ -7,6 +7,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../parent/terragrunt.hcl
     - some_parent_dep
     - ../file_in_parent_of_child.json
     - ../../parent/folder_under_parent/common_tags.hcl
@@ -17,6 +18,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../parent/terragrunt.hcl
     - some_parent_dep
     - local_tags.yaml
     - ../file_in_parent_of_child.json

--- a/cmd/golden/multi_accounts_vpc_route53_tgw.yaml
+++ b/cmd/golden/multi_accounts_vpc_route53_tgw.yaml
@@ -7,12 +7,14 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
   dir: network-account/eu-west-1/network/transit-gateway
 - autoplan:
     enabled: false
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../../terragrunt.hcl
     - ../../../env-a/network/vpc/terragrunt.hcl
     - ../../../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
   dir: prod/eu-west-1/_global/route53/test-zone
@@ -21,6 +23,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../../terragrunt.hcl
     - ../../../../../network-account/eu-west-1/network/transit-gateway/terragrunt.hcl
   dir: prod/eu-west-1/env-a/network/vpc
 version: 3

--- a/cmd/golden/multiple_includes.yaml
+++ b/cmd/golden/multiple_includes.yaml
@@ -7,6 +7,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../use_terraform_12_parent.hcl
+    - ../use_terraform_13_parent.hcl
   dir: includes_tf_12_then_13
   terraform_version: 0.13.9001
 - autoplan:
@@ -14,6 +16,8 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../use_terraform_13_parent.hcl
+    - ../use_terraform_12_parent.hcl
   dir: includes_tf_13_then_12
   terraform_version: 0.12.9001
 - autoplan:
@@ -21,6 +25,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../use_terraform_12_parent.hcl
   dir: uses_terraform_12
   terraform_version: 0.12.9001
 - autoplan:
@@ -28,6 +33,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../use_terraform_13_parent.hcl
   dir: uses_terraform_13
   terraform_version: 0.13.9001
 version: 3

--- a/cmd/golden/no_terraform_blocks.yml
+++ b/cmd/golden/no_terraform_blocks.yml
@@ -7,6 +7,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../network/terragrunt.hcl
     - ../../stage/network/terragrunt.hcl
   dir: myproject/eu-south-1/infra/apps
@@ -15,6 +16,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../../stage/network/terragrunt.hcl
   dir: myproject/eu-south-1/infra/network
 - autoplan:
@@ -22,6 +24,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
     - ../network/terragrunt.hcl
   dir: myproject/eu-south-1/stage/dbs
 - autoplan:
@@ -29,17 +32,20 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../../terragrunt.hcl
   dir: myproject/eu-south-1/stage/network
 - autoplan:
     enabled: true
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../terragrunt.hcl
   dir: myproject/global/dns
 - autoplan:
     enabled: true
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../../terragrunt.hcl
   dir: myproject/global/iam
 version: 3

--- a/cmd/golden/parentAndChildDefinedWorkflow.yaml
+++ b/cmd/golden/parentAndChildDefinedWorkflow.yaml
@@ -7,6 +7,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: child
   workflow: workflowSpecifiedInChild
 version: 3

--- a/cmd/golden/parentDefinedWorkflow.yaml
+++ b/cmd/golden/parentDefinedWorkflow.yaml
@@ -7,6 +7,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: child
   workflow: workflowSpecifiedInParent
 version: 3

--- a/cmd/golden/project_marker.yaml
+++ b/cmd/golden/project_marker.yaml
@@ -9,6 +9,7 @@ projects:
     - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
+    - ../../../terragrunt.hcl
     - ../../account.hcl
     - ../region.hcl
     - ../../arbitrary.hcl

--- a/cmd/golden/skip.yaml
+++ b/cmd/golden/skip.yaml
@@ -7,5 +7,6 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: skip_false
 version: 3

--- a/cmd/golden/terraform_version.yaml
+++ b/cmd/golden/terraform_version.yaml
@@ -7,6 +7,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: inherit_from_parent
   terraform_version: 0.12.9001
 - autoplan:
@@ -14,6 +15,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: override_parent
   terraform_version: 0.13.9001
 - autoplan:

--- a/cmd/golden/withOriginalDir.yaml
+++ b/cmd/golden/withOriginalDir.yaml
@@ -7,6 +7,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
     - ../common/terragrunt.hcl
     - ../dependency/terragrunt.hcl
   dir: child
@@ -15,5 +16,6 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: dependency
 version: 3

--- a/cmd/golden/withParent.yaml
+++ b/cmd/golden/withParent.yaml
@@ -13,5 +13,6 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: child
 version: 3

--- a/cmd/golden/withProjectName.yaml
+++ b/cmd/golden/withProjectName.yaml
@@ -7,6 +7,7 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../../terragrunt.hcl
   dir: child/deep
   name: child_deep
 version: 3

--- a/cmd/golden/withoutParent.yaml
+++ b/cmd/golden/withoutParent.yaml
@@ -7,5 +7,6 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
   dir: child
 version: 3

--- a/cmd/parse_hcl.go
+++ b/cmd/parse_hcl.go
@@ -2,24 +2,117 @@ package cmd
 
 import (
 	"github.com/gruntwork-io/terragrunt/config"
+	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclparse"
-	"github.com/zclconf/go-cty/cty/function"
+	"github.com/hashicorp/hcl/v2/hclwrite"
 )
 
+const bareIncludeKey = ""
+
 type parsedHcl struct {
-	Terraform *terraformConfig `hcl:"terraform,block"`
-	Includes  *includeConfig   `hcl:"include,block"`
+	Terraform *config.TerraformConfig `hcl:"terraform,block"`
+	Includes  []config.IncludeConfig  `hcl:"include,block"`
 }
 
-type terraformConfig struct {
-	Source *string `hcl:"source,attr"`
+// terragruntIncludeMultiple is a struct that can be used to only decode the include block with labels.
+type terragruntIncludeMultiple struct {
+	Include []config.IncludeConfig `hcl:"include,block"`
+	Remain  hcl.Body               `hcl:",remain"`
 }
 
-type includeConfig struct {
-	Path *string `hcl:"path,attr"`
+// updateBareIncludeBlock searches the parsed terragrunt contents for a bare include block (include without a label),
+// and convert it to one with empty string as the label. This is necessary because the hcl parser is strictly enforces
+// label counts when parsing out labels with a go struct.
+//
+// Returns the updated contents, a boolean indicated whether anything changed, and an error (if any).
+func updateBareIncludeBlock(file *hcl.File, filename string) ([]byte, bool, error) {
+	hclFile, err := hclwrite.ParseConfig(file.Bytes, filename, hcl.InitialPos)
+	if err != nil {
+		return nil, false, errors.WithStackTrace(err)
+	}
+
+	codeWasUpdated := false
+	for _, block := range hclFile.Body().Blocks() {
+		if block.Type() == "include" && len(block.Labels()) == 0 {
+			if codeWasUpdated {
+				return nil, false, errors.WithStackTrace(config.MultipleBareIncludeBlocksErr{})
+			}
+			block.SetLabels([]string{bareIncludeKey})
+			codeWasUpdated = true
+		}
+	}
+	return hclFile.Bytes(), codeWasUpdated, nil
+}
+
+// decodeHcl uses the HCL2 parser to decode the parsed HCL into the struct specified by out.
+//
+// Note that we take a two pass approach to support parsing include blocks without a label. Ideally we can parse include
+// blocks with and without labels in a single pass, but the HCL parser is fairly restrictive when it comes to parsing
+// blocks with labels, requiring the exact number of expected labels in the parsing step.  To handle this restriction,
+// we first see if there are any include blocks without any labels, and if there is, we modify it in the file object to
+// inject the label as "".
+func decodeHcl(
+	file *hcl.File,
+	filename string,
+	out interface{},
+	terragruntOptions *options.TerragruntOptions,
+	extensions config.EvalContextExtensions,
+) (err error) {
+	// The HCL2 parser and especially cty conversions will panic in many types of errors, so we have to recover from
+	// those panics here and convert them to normal errors
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = errors.WithStackTrace(config.PanicWhileParsingConfig{RecoveredValue: recovered, ConfigFile: filename})
+		}
+	}()
+
+	// Check if we need to update the file to label any bare include blocks.
+	updatedBytes, isUpdated, err := updateBareIncludeBlock(file, filename)
+	if err != nil {
+		return err
+	}
+	if isUpdated {
+		// Code was updated, so we need to reparse the new updated contents. This is necessarily because the blocks
+		// returned by hclparse does not support editing, and so we have to go through hclwrite, which leads to a
+		// different AST representation.
+		file, err = parseHcl(hclparse.NewParser(), string(updatedBytes), filename)
+		if err != nil {
+			return err
+		}
+	}
+
+	evalContext, err := config.CreateTerragruntEvalContext(filename, terragruntOptions, extensions)
+	if err != nil {
+		return err
+	}
+
+	decodeDiagnostics := gohcl.DecodeBody(file.Body, evalContext, out)
+	if decodeDiagnostics != nil && decodeDiagnostics.HasErrors() {
+		return decodeDiagnostics
+	}
+
+	return nil
+}
+
+// This decodes only the `include` blocks of a terragrunt config, so its value can be used while decoding the rest of
+// the config.
+// For consistency, `include` in the call to `decodeHcl` is always assumed to be nil. Either it really is nil (parsing
+// the child config), or it shouldn't be used anyway (the parent config shouldn't have an include block).
+func decodeAsTerragruntInclude(
+	file *hcl.File,
+	filename string,
+	terragruntOptions *options.TerragruntOptions,
+	extensions config.EvalContextExtensions,
+) ([]config.IncludeConfig, error) {
+	tgInc := terragruntIncludeMultiple{}
+	if err := decodeHcl(file, filename, &tgInc, terragruntOptions, extensions); err != nil {
+		return nil, err
+	}
+	return tgInc.Include, nil
 }
 
 // Not all modules need an include statement, as they could define everything in one file without a parent
@@ -27,41 +120,39 @@ type includeConfig struct {
 //   - no include statement
 //   - no terraform source defined
 // If both of those are true, it is likely a parent module
-func isParentModule(path string, terragruntOptions *options.TerragruntOptions) (bool, error) {
+func parseModule(path string, terragruntOptions *options.TerragruntOptions) (isParent bool, includes []config.IncludeConfig, err error) {
 	configString, err := util.ReadFileAsString(path)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 
 	parser := hclparse.NewParser()
 	file, err := parseHcl(parser, configString, path)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 
+	// Decode just the `include` and `import` blocks, and verify that it's allowed here
 	extensions := config.EvalContextExtensions{}
-	evalContext, err := config.CreateTerragruntEvalContext(path, terragruntOptions, extensions)
+	terragruntIncludeList, err := decodeAsTerragruntInclude(file, path, terragruntOptions, extensions)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 
-	// Mock all the functions out so they don't do anything. Otherwise they may throw errors that we don't care about
-	evalContext.Functions = map[string]function.Function{}
+	// If the file has any `include` blocks it is not a parent
+	if len(terragruntIncludeList) > 0 {
+		return false, terragruntIncludeList, nil
+	}
 
-	// We don't need to check the errors/diagnostics coming from `DecodeBody`, as when errors come up,
+	// We don't need to check the errors/diagnostics coming from `decodeHcl`, as when errors come up,
 	// it will leave the partially parsed result in the output object.
 	var parsed parsedHcl
-	gohcl.DecodeBody(file.Body, evalContext, &parsed)
-
-	// If the file has an `includes` block, it cannot be a parent as terragrunt only allows one level of inheritance
-	if parsed.Includes != nil && parsed.Includes.Path != nil {
-		return false, nil
-	}
+	decodeHcl(file, path, &parsed, terragruntOptions, extensions)
 
 	// If the file does not define a terraform source block, it is likely a parent (though not guaranteed)
 	if parsed.Terraform == nil || parsed.Terraform.Source == nil {
-		return true, nil
+		return true, nil, nil
 	}
 
-	return false, nil
+	return false, nil, nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -13,9 +12,10 @@ var (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "terragrunt-atlantis-config",
-	Short: "Generates Atlantis Config for Terragrunt projects",
-	Long:  "Generates Atlantis Config for Terragrunt projects",
+	Use:          "terragrunt-atlantis-config",
+	Short:        "Generates Atlantis Config for Terragrunt projects",
+	Long:         "Generates Atlantis Config for Terragrunt projects",
+	SilenceUsage: true,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -24,7 +24,6 @@ func Execute(version string) {
 	VERSION = version
 
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/transcend-io/terragrunt-atlantis-config
 
-go 1.14
+go 1.16
 
 require (
 	github.com/bmatcuk/doublestar v1.3.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/bmatcuk/doublestar v1.3.1 // indirect
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-errors/errors v1.1.1 // indirect
-	github.com/gruntwork-io/terragrunt v0.35.19
+	github.com/gruntwork-io/terragrunt v0.36.1
 	github.com/hashicorp/go-getter v1.5.9
-	github.com/hashicorp/hcl/v2 v2.10.0
+	github.com/hashicorp/hcl/v2 v2.11.1
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20210625153042-09f34846faab
 	github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c // indirect
 	github.com/imdario/mergo v0.3.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -477,7 +477,6 @@ github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/gotestyourself/gotestyourself v2.2.0+incompatible h1:AQwinXlbQR2HvPjQZOmDhRqsv5mZf+Jb1RnSLxcqZcI=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/goware/prefixer v0.0.0-20160118172347-395022866408 h1:Y9iQJfEqnN3/Nce9cOegemcy/9Ai5k3huT6E80F3zaw=
 github.com/goware/prefixer v0.0.0-20160118172347-395022866408/go.mod h1:PE1ycukgRPJ7bJ9a1fdfQ9j8i/cEcRAoLZzbxYpNB/s=
@@ -1437,7 +1436,6 @@ gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107172259-749611fa9fcc h1:XANm4xAMEQhRdWKqaL0qmhGDv7RuobwCO97TIlktaQE=
 gopkg.in/yaml.v3 v3.0.0-20210107172259-749611fa9fcc/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go.sum
+++ b/go.sum
@@ -489,8 +489,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.8.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/gruntwork-io/gruntwork-cli v0.7.0/go.mod h1:jp6Z7NcLF2avpY8v71fBx6hds9eOFPELSuD/VPv7w00=
-github.com/gruntwork-io/terragrunt v0.35.19 h1:Iy7xJLRK8b1rlzbzAFVU5korp5hfp9+20EY6528dkKk=
-github.com/gruntwork-io/terragrunt v0.35.19/go.mod h1:RrG5599JjmyVx/6AIS1coH6XTj5UOI9BPXZv9ImAfxA=
+github.com/gruntwork-io/terragrunt v0.36.1 h1:H2hw2lieopGpMfllmqPjJ9sFI+fCRxHj4l/jg4hCPoA=
+github.com/gruntwork-io/terragrunt v0.36.1/go.mod h1:RrG5599JjmyVx/6AIS1coH6XTj5UOI9BPXZv9ImAfxA=
 github.com/gruntwork-io/terratest v0.32.6 h1:OEA11ZqEwKRowEdxusDnAPnMUN0w/jzeNcziuQsqkYk=
 github.com/gruntwork-io/terratest v0.32.6/go.mod h1:0iy7d56CziX3R4ZUn570HMElr4WgBKoKNa8Hzex7bvo=
 github.com/hashicorp/aws-sdk-go-base v0.6.0/go.mod h1:2fRjWDv3jJBeN6mVWFHV6hFTNeFBx2gpDLQaZNxUVAY=
@@ -563,8 +563,9 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hashicorp/hcl v1.0.1-vault h1:UiJeEzCWAYdVaJr8Xo4lBkTozlW1+1yxVUnpbS1xVEk=
 github.com/hashicorp/hcl v1.0.1-vault/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl/v2 v2.0.0/go.mod h1:oVVDG71tEinNGYCxinCYadcmKU9bglqW9pV3txagJ90=
-github.com/hashicorp/hcl/v2 v2.10.0 h1:1S1UnuhDGlv3gRFV4+0EdwB+znNP5HmcGbIqwnSCByg=
 github.com/hashicorp/hcl/v2 v2.10.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
+github.com/hashicorp/hcl/v2 v2.11.1 h1:yTyWcXcm9XB0TEkyU/JCRU6rYy4K+mgLtzn2wlrJbcc=
+github.com/hashicorp/hcl/v2 v2.11.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/jsonapi v0.0.0-20210420151930-edf82c9774bf/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/hashicorp/memberlist v0.1.0/go.mod h1:ncdBp14cuox2iFOq3kDiquKU6fqsTBc3W6JvZwjxxsE=
 github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb/go.mod h1:h/Ru6tmZazX7WO/GDmwdpS975F019L4t5ng5IgwbNrE=

--- a/test_examples/terragrunt-infrastructure-live-example/README.md
+++ b/test_examples/terragrunt-infrastructure-live-example/README.md
@@ -15,6 +15,10 @@ the Terraform code, defined in the `terragrunt-infrastructure-modules-example` r
 `terragrunt.hcl` files that reference that code (at a specific version, too!) and fill in variables specific to each
 environment.
 
+Be sure to read through [the Terragrunt documentation on DRY
+Architectures](https://terragrunt.gruntwork.io/docs/features/keep-your-terragrunt-architecture-dry/) to understand the
+features of Terragrunt used in this folder organization.
+
 Note: This code is solely for demonstration purposes. This is not production-ready code, so use at your own risk. If
 you are interested in battle-tested, production-ready Terraform code, check out [Gruntwork](http://www.gruntwork.io/).
 
@@ -26,14 +30,16 @@ you are interested in battle-tested, production-ready Terraform code, check out 
 
 ### Pre-requisites
 
-1. Install [Terraform](https://www.terraform.io/) version `0.12.0` or newer and
-   [Terragrunt](https://github.com/gruntwork-io/terragrunt) version `v0.23.0` or newer.
-1. Update the `bucket` parameter in `non-prod/terragrunt.hcl` and `prod/terragrunt.hcl` to unique names. We use S3
-   [as a Terraform backend](https://www.terraform.io/docs/backends/types/s3.html) to store your Terraform state, and
-   S3 bucket names must be globally unique. The names currently in the file are already taken, so you'll have to
-   specify your own. Alternatives, you can set the environment variable `TG_BUCKET_PREFIX` to set a custom prefix.
+1. Install [Terraform](https://www.terraform.io/) version `0.13.0` or newer and
+   [Terragrunt](https://github.com/gruntwork-io/terragrunt) version `v0.32.0` or newer.
+1. Update the `bucket` parameter in the root `terragrunt.hcl`. We use S3 [as a Terraform
+   backend](https://www.terraform.io/docs/backends/types/s3.html) to store your
+   Terraform state, and S3 bucket names must be globally unique. The name currently in
+   the file is already taken, so you'll have to specify your own. Alternatives, you can
+   set the environment variable `TG_BUCKET_PREFIX` to set a custom prefix.
 1. Configure your AWS credentials using one of the supported [authentication
    mechanisms](https://www.terraform.io/docs/providers/aws/#authentication).
+1. Fill in your AWS Account ID's in `prod/account.hcl` and `non-prod/account.hcl`.
 
 
 ### Deploying a single module

--- a/test_examples/terragrunt-infrastructure-live-example/_envcommon/README.md
+++ b/test_examples/terragrunt-infrastructure-live-example/_envcommon/README.md
@@ -1,0 +1,7 @@
+# Common configurations for service components
+
+This directory holds common configurations for each component that is shared across the environments. Each file
+will be included and merged into the live configuration for the service component in each environment.
+
+Refer to [the Terragrunt
+documentation](https://terragrunt.gruntwork.io/docs/features/keep-your-terragrunt-architecture-dry/) for more details.

--- a/test_examples/terragrunt-infrastructure-live-example/_envcommon/mysql.hcl
+++ b/test_examples/terragrunt-infrastructure-live-example/_envcommon/mysql.hcl
@@ -1,0 +1,46 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# COMMON TERRAGRUNT CONFIGURATION
+# This is the common component configuration for mysql. The common variables for each environment to
+# deploy mysql are defined here. This configuration will be merged into the environment configuration
+# via an include block.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder. If any environment
+# needs to deploy a different module version, it should redefine this block with a different ref to override the
+# deployed version.
+terraform {
+  source = "${local.base_source_url}?ref=v0.4.0"
+}
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Locals are named constants that are reusable within the configuration.
+# ---------------------------------------------------------------------------------------------------------------------
+locals {
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+
+  # Extract out common variables for reuse
+  env = local.environment_vars.locals.environment
+
+  # Expose the base source URL so different versions of the module can be deployed in different environments. This will
+  # be used to construct the terraform block in the child terragrunt configurations.
+  base_source_url = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//mysql"
+}
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE PARAMETERS
+# These are the variables we have to pass in to use the module. This defines the parameters that are common across all
+# environments.
+# ---------------------------------------------------------------------------------------------------------------------
+inputs = {
+  name              = "mysql_${local.env}"
+  instance_class    = "db.t2.micro"
+  allocated_storage = 20
+  storage_type      = "standard"
+  master_username   = "admin"
+
+  # TODO: To avoid storing your DB password in the code, set it as the environment variable TF_VAR_master_password
+}

--- a/test_examples/terragrunt-infrastructure-live-example/_envcommon/webserver-cluster.hcl
+++ b/test_examples/terragrunt-infrastructure-live-example/_envcommon/webserver-cluster.hcl
@@ -1,0 +1,36 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# COMMON TERRAGRUNT CONFIGURATION
+# This is the common component configuration for webserver-cluster. The common variables for each environment to
+# deploy webserver-cluster are defined here. This configuration will be merged into the environment configuration
+# via an include block.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Locals are named constants that are reusable within the configuration.
+# ---------------------------------------------------------------------------------------------------------------------
+locals {
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+
+  # Extract out common variables for reuse
+  env = local.environment_vars.locals.environment
+
+  # Expose the base source URL so different versions of the module can be deployed in different environments.
+  base_source_url = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//asg-elb-service"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE PARAMETERS
+# These are the variables we have to pass in to use the module. This defines the parameters that are common across all
+# environments.
+# ---------------------------------------------------------------------------------------------------------------------
+inputs = {
+  name          = "webserver-example-${local.env}"
+  instance_type = "t2.micro"
+
+  min_size = 2
+  max_size = 2
+
+  server_port = 8080
+  elb_port    = 80
+}

--- a/test_examples/terragrunt-infrastructure-live-example/non-prod/us-east-1/qa/mysql/terragrunt.hcl
+++ b/test_examples/terragrunt-infrastructure-live-example/non-prod/us-east-1/qa/mysql/terragrunt.hcl
@@ -1,31 +1,34 @@
-locals {
-  # Automatically load environment-level variables
-  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# This is the configuration for Terragrunt, a thin wrapper for Terraform that helps keep your code DRY and
+# maintainable: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
 
-  # Extract out common variables for reuse
-  env = local.environment_vars.locals.environment
-}
-
-# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
-# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+# We override the terraform block source attribute here just for the QA environment to show how you would deploy a
+# different version of the module in a specific environment.
 terraform {
-  source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//mysql?ref=v0.3.0"
+  source = "${include.envcommon.locals.base_source_url}?ref=v0.4.0"
 }
 
-# Include all settings from the root terragrunt.hcl file
-include {
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Include configurations that are common used across multiple environments.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# Include the root `terragrunt.hcl` configuration. The root configuration contains settings that are common across all
+# components and environments, such as how to configure remote state.
+include "root" {
   path = find_in_parent_folders()
 }
 
-# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
-inputs = {
-  name           = "mysql_${local.env}"
-  instance_class = "db.t2.micro"
-
-  allocated_storage = 20
-  storage_type      = "standard"
-
-  master_username = "admin"
-  # TODO: To avoid storing your DB password in the code, set it as the environment variable TF_VAR_master_password
+# Include the envcommon configuration for the component. The envcommon configuration contains settings that are common
+# for the component across all environments.
+include "envcommon" {
+  path   = "${dirname(find_in_parent_folders())}/_envcommon/mysql.hcl"
+  expose = true
 }
 
+
+# ---------------------------------------------------------------------------------------------------------------------
+# We don't need to override any of the common parameters for this environment, so we don't specify any inputs.
+# ---------------------------------------------------------------------------------------------------------------------

--- a/test_examples/terragrunt-infrastructure-live-example/non-prod/us-east-1/qa/webserver-cluster/terragrunt.hcl
+++ b/test_examples/terragrunt-infrastructure-live-example/non-prod/us-east-1/qa/webserver-cluster/terragrunt.hcl
@@ -1,30 +1,34 @@
-locals {
-  # Automatically load environment-level variables
-  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# This is the configuration for Terragrunt, a thin wrapper for Terraform that helps keep your code DRY and
+# maintainable: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
 
-  # Extract out common variables for reuse
-  env = local.environment_vars.locals.environment
-}
-
-# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
-# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+# We override the terraform block source attribute here just for the QA environment to show how you would deploy a
+# different version of the module in a specific environment.
 terraform {
-  source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//asg-elb-service?ref=v0.3.0"
+  source = "${include.envcommon.locals.base_source_url}?ref=v0.4.0"
 }
 
-# Include all settings from the root terragrunt.hcl file
-include {
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Include configurations that are common used across multiple environments.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# Include the root `terragrunt.hcl` configuration. The root configuration contains settings that are common across all
+# components and environments, such as how to configure remote state.
+include "root" {
   path = find_in_parent_folders()
 }
 
-# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
-inputs = {
-  name          = "webserver-example-${local.env}"
-  instance_type = "t2.micro"
-
-  min_size = 2
-  max_size = 2
-
-  server_port = 8080
-  elb_port    = 80
+# Include the envcommon configuration for the component. The envcommon configuration contains settings that are common
+# for the component across all environments.
+include "envcommon" {
+  path   = "${dirname(find_in_parent_folders())}/_envcommon/webserver-cluster.hcl"
+  expose = true
 }
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# We don't need to override any of the common parameters for this environment, so we don't specify any inputs.
+# ---------------------------------------------------------------------------------------------------------------------

--- a/test_examples/terragrunt-infrastructure-live-example/non-prod/us-east-1/stage/mysql/terragrunt.hcl
+++ b/test_examples/terragrunt-infrastructure-live-example/non-prod/us-east-1/stage/mysql/terragrunt.hcl
@@ -1,30 +1,26 @@
-locals {
-  # Automatically load environment-level variables
-  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# This is the configuration for Terragrunt, a thin wrapper for Terraform that helps keep your code DRY and
+# maintainable: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
 
-  # Extract out common variables for reuse
-  env = local.environment_vars.locals.environment
-}
+# ---------------------------------------------------------------------------------------------------------------------
+# Include configurations that are common used across multiple environments.
+# ---------------------------------------------------------------------------------------------------------------------
 
-# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
-# working directory, into a temporary folder, and execute your Terraform commands in that folder.
-terraform {
-  source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//mysql?ref=v0.3.0"
-}
-
-# Include all settings from the root terragrunt.hcl file
-include {
+# Include the root `terragrunt.hcl` configuration. The root configuration contains settings that are common across all
+# components and environments, such as how to configure remote state.
+include "root" {
   path = find_in_parent_folders()
 }
 
-# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
-inputs = {
-  name           = "mysql_${local.env}"
-  instance_class = "db.t2.micro"
-
-  allocated_storage = 20
-  storage_type      = "standard"
-
-  master_username = "admin"
-  # TODO: To avoid storing your DB password in the code, set it as the environment variable TF_VAR_master_password
+# Include the envcommon configuration for the component. The envcommon configuration contains settings that are common
+# for the component across all environments.
+include "envcommon" {
+  path = "${dirname(find_in_parent_folders())}/_envcommon/mysql.hcl"
 }
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# We don't need to override any of the common parameters for this environment, so we don't specify any other parameters.
+# ---------------------------------------------------------------------------------------------------------------------

--- a/test_examples/terragrunt-infrastructure-live-example/non-prod/us-east-1/stage/webserver-cluster/terragrunt.hcl
+++ b/test_examples/terragrunt-infrastructure-live-example/non-prod/us-east-1/stage/webserver-cluster/terragrunt.hcl
@@ -1,30 +1,26 @@
-locals {
-  # Automatically load environment-level variables
-  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# This is the configuration for Terragrunt, a thin wrapper for Terraform that helps keep your code DRY and
+# maintainable: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
 
-  # Extract out common variables for reuse
-  env = local.environment_vars.locals.environment
-}
+# ---------------------------------------------------------------------------------------------------------------------
+# Include configurations that are common used across multiple environments.
+# ---------------------------------------------------------------------------------------------------------------------
 
-# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
-# working directory, into a temporary folder, and execute your Terraform commands in that folder.
-terraform {
-  source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//asg-elb-service?ref=v0.3.0"
-}
-
-# Include all settings from the root terragrunt.hcl file
-include {
+# Include the root `terragrunt.hcl` configuration. The root configuration contains settings that are common across all
+# components and environments, such as how to configure remote state.
+include "root" {
   path = find_in_parent_folders()
 }
 
-# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
-inputs = {
-  name          = "webserver-example-${local.env}"
-  instance_type = "t2.micro"
-
-  min_size = 2
-  max_size = 2
-
-  server_port = 8080
-  elb_port    = 80
+# Include the envcommon configuration for the component. The envcommon configuration contains settings that are common
+# for the component across all environments.
+include "envcommon" {
+  path = "${dirname(find_in_parent_folders())}/_envcommon/webserver-cluster.hcl"
 }
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# We don't need to override any of the common parameters for this environment, so we don't specify any other parameters.
+# ---------------------------------------------------------------------------------------------------------------------

--- a/test_examples/terragrunt-infrastructure-live-example/prod/us-east-1/prod/mysql/terragrunt.hcl
+++ b/test_examples/terragrunt-infrastructure-live-example/prod/us-east-1/prod/mysql/terragrunt.hcl
@@ -1,30 +1,33 @@
-locals {
-  # Automatically load environment-level variables
-  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# This is the configuration for Terragrunt, a thin wrapper for Terraform that helps keep your code DRY and
+# maintainable: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
 
-  # Extract out common variables for reuse
-  env = local.environment_vars.locals.environment
-}
+# ---------------------------------------------------------------------------------------------------------------------
+# Include configurations that are common used across multiple environments.
+# ---------------------------------------------------------------------------------------------------------------------
 
-# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
-# working directory, into a temporary folder, and execute your Terraform commands in that folder.
-terraform {
-  source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//mysql?ref=v0.3.0"
-}
-
-# Include all settings from the root terragrunt.hcl file
-include {
+# Include the root `terragrunt.hcl` configuration. The root configuration contains settings that are common across all
+# components and environments, such as how to configure remote state.
+include "root" {
   path = find_in_parent_folders()
 }
 
-# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+# Include the envcommon configuration for the component. The envcommon configuration contains settings that are common
+# for the component across all environments.
+include "envcommon" {
+  path = "${dirname(find_in_parent_folders())}/_envcommon/mysql.hcl"
+}
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Override parameters for this environment
+# ---------------------------------------------------------------------------------------------------------------------
+
+# For production, we want to specify bigger instance classes and storage, so we specify override parameters here. These
+# inputs get merged with the common inputs from the root and the envcommon terragrunt.hcl
 inputs = {
-  name           = "mysql_${local.env}"
-  instance_class = "db.t2.medium"
-
+  instance_class    = "db.t2.medium"
   allocated_storage = 100
-  storage_type      = "standard"
-
-  master_username = "admin"
-  # TODO: To avoid storing your DB password in the code, set it as the environment variable TF_VAR_master_password
 }

--- a/test_examples/terragrunt-infrastructure-live-example/prod/us-east-1/prod/webserver-cluster/terragrunt.hcl
+++ b/test_examples/terragrunt-infrastructure-live-example/prod/us-east-1/prod/webserver-cluster/terragrunt.hcl
@@ -1,30 +1,35 @@
-locals {
-  # Automatically load environment-level variables
-  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# This is the configuration for Terragrunt, a thin wrapper for Terraform that helps keep your code DRY and
+# maintainable: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
 
-  # Extract out common variables for reuse
-  env = local.environment_vars.locals.environment
-}
+# ---------------------------------------------------------------------------------------------------------------------
+# Include configurations that are common used across multiple environments.
+# ---------------------------------------------------------------------------------------------------------------------
 
-# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
-# working directory, into a temporary folder, and execute your Terraform commands in that folder.
-terraform {
-  source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//asg-elb-service?ref=v0.3.0"
-}
-
-# Include all settings from the root terragrunt.hcl file
-include {
+# Include the root `terragrunt.hcl` configuration. The root configuration contains settings that are common across all
+# components and environments, such as how to configure remote state.
+include "root" {
   path = find_in_parent_folders()
 }
 
-# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+# Include the envcommon configuration for the component. The envcommon configuration contains settings that are common
+# for the component across all environments.
+include "envcommon" {
+  path = "${dirname(find_in_parent_folders())}/_envcommon/webserver-cluster.hcl"
+}
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Override parameters for this environment
+# ---------------------------------------------------------------------------------------------------------------------
+
+# For production, we want to specify bigger instance classes and cluster, so we specify override parameters here. These
+# inputs get merged with the common inputs from the root and the envcommon terragrunt.hcl
 inputs = {
-  name          = "webserver-example-${local.env}"
   instance_type = "t2.medium"
 
   min_size = 3
   max_size = 3
-
-  server_port = 8080
-  elb_port    = 80
 }


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- #155 
- #176
- #196
- #199  

## Description

This adds support for the "common module" pattern that was recently added to the [Terragrunt example repo](https://github.com/gruntwork-io/terragrunt-infrastructure-live-example). In addition it also automatically adds the included path as a dependency without requiring any `extra_atlantis_dependencies` blocks.

There is an important caveat to this approach however, _every_ include block is added as an implicit dependency, including any parent module. This means that irrespective of the state of  `--ignore-parent-terragrunt` the parent `terragrunt.hcl` will be included as there is no _easy_ way differentiate between includes to find the "real" parent. For that reason I'm marking this as a draft as we will need something akin to the idea discussed in #155 in order to properly support that functionality. 

I played around with the idea of adding a `is_parent_terragrunt_file` flag, but couldn't figure out the logic for it. That's the reason the `--include-parent-changes` cli argument still exists below, looks like I missed it in the change set.

This also adds a new functional cli argument `--create-parent-project` as I see a potential to _want_ to include the parent as a dependency but not create a project for it. So these two arguments are the two components of those changes, with `--ignore-parent-terragrunt` disabling both. These should provide enough flexibility to cover most uses of parent modules.

Lastly, there are two minor changes to how the error handling works. First, the printing of the usage/help is now suppressed when exiting with an error. This was something that kept coming up during debugging and it made things a bit easier to view. Also, this removes the second printing of any error, again because this was cleaner during debugging. 

## Security Implications

- _[none]_

## System Availability

- _[none]_
