### PR TITLE
Support incremental builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.12.5
+VERSION=1.13.0
 PATH_BUILD=build/
 FILE_COMMAND=terragrunt-atlantis-config
 FILE_ARCH=darwin_amd64

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then, make sure `terragrunt-atlantis-config` is present on your Atlantis server.
 
 ```hcl
 variable "terragrunt_atlantis_config_version" {
-  default = "1.12.5"
+  default = "1.13.0"
 }
 
 build {
@@ -122,6 +122,7 @@ One way to customize the behavior of this module is through CLI flag values pass
 | `--create-workspace`         | Use different auto-generated workspace for each project. Default is use default workspace for everything                                                                        | false             |
 | `--create-project-name`      | Add different auto-generated name for each project                                                                                                                              | false             |
 | `--preserve-workflows`       | Preserves workflows from old output files. Useful if you want to define your workflow definitions on the client side                                                            | true              |
+| `--preserve-projects`        | Preserves projects from old output files. Useful for incremental builds using `--filter` | false              |
 | `--workflow`                 | Name of the workflow to be customized in the atlantis server. If empty, will be left out of output                                                                              | ""                |
 | `--apply-requirements`    | Requirements that must be satisfied before `atlantis apply` can be run. Currently the only supported requirements are `approved` and `mergeable`. Can be overridden by locals   | []                |
 | `--output`                   | Path of the file where configuration will be generated. Typically, you want a file named "atlantis.yaml". Default is to write to `stdout`.                                      | ""                |
@@ -189,7 +190,7 @@ You can install this tool locally to checkout what kinds of config it will gener
 Recommended: Install any version via go get:
 
 ```bash
-cd && GO111MODULE=on go get github.com/transcend-io/terragrunt-atlantis-config@v1.12.5 && cd -
+cd && GO111MODULE=on go get github.com/transcend-io/terragrunt-atlantis-config@v1.13.0 && cd -
 ```
 
 This module officially supports golang versions v1.13, v1.14, v1.15, and v1.16, tested on CircleCI with each build

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -669,6 +669,9 @@ func main(cmd *cobra.Command, args []string) error {
 	if oldConfig != nil && preserveWorkflows {
 		config.Workflows = oldConfig.Workflows
 	}
+	if oldConfig != nil && preserveProjects {
+		config.Projects = oldConfig.Projects
+	}
 
 	lock := sync.Mutex{}
 	ctx := context.Background()

--- a/cmd/golden/oldProjectsPreserved.yaml
+++ b/cmd/golden/oldProjectsPreserved.yaml
@@ -1,0 +1,18 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: .
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: someDir
+  name: projectFromPreviousRun
+version: 3

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import "github.com/transcend-io/terragrunt-atlantis-config/cmd"
 // This variable is set at build time using -ldflags parameters.
 // But we still set a default here for those using plain `go get` downloads
 // For more info, see: http://stackoverflow.com/a/11355611/483528
-var VERSION string = "1.12.5"
+var VERSION string = "1.13.0"
 
 func main() {
 	cmd.Execute(VERSION)


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- Closes https://github.com/transcend-io/terragrunt-atlantis-config/issues/152

## Description

Supports incremental builds by adding a new flag `--preserve-projects`, defaulting to false, that keeps old `atlantis.yaml` projects when writing out new ones
