### PR TITLE
When using --preserve-projects and --filter options together, replace existing block instead of duplicating it

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -747,8 +747,28 @@ func main(cmd *cobra.Command, args []string) error {
 					lock.Lock()
 					defer lock.Unlock()
 
-					log.Info("Created project for ", terragruntPath)
-					config.Projects = append(config.Projects, *project)
+					// When preserving existing projects, we should update existing blocks instead of creating a
+					// duplicate, when generating something which already has representation
+					// TODO: once we upgrade to GoLang 1.19, use slices.IndexFunc instead of iterating over range
+					if preserveProjects {
+						updateProject := false
+
+						for i := range config.Projects {
+							if config.Projects[i].Dir == project.Dir {
+								updateProject = true
+								log.Info("Updated project for ", terragruntPath)
+								config.Projects[i] = *project
+							}
+						}
+
+						if !updateProject {
+							log.Info("Created project for ", terragruntPath)
+							config.Projects = append(config.Projects, *project)
+						}
+					} else {
+						log.Info("Created project for ", terragruntPath)
+						config.Projects = append(config.Projects, *project)
+					}
 
 					return nil
 				})

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -749,15 +749,19 @@ func main(cmd *cobra.Command, args []string) error {
 
 					// When preserving existing projects, we should update existing blocks instead of creating a
 					// duplicate, when generating something which already has representation
-					// TODO: once we upgrade to GoLang 1.19, use slices.IndexFunc instead of iterating over range
 					if preserveProjects {
 						updateProject := false
 
+						// TODO: with Go 1.19, we can replace for loop with slices.IndexFunc for increased performance
 						for i := range config.Projects {
 							if config.Projects[i].Dir == project.Dir {
 								updateProject = true
 								log.Info("Updated project for ", terragruntPath)
 								config.Projects[i] = *project
+
+								// projects should be unique, let's exit for loop for performance
+								// once first occurrence is found and replaced
+								break
 							}
 						}
 


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- https://github.com/transcend-io/terragrunt-atlantis-config/issues/208

## Description

When using  `--preserve-projects` and `--filter` options together, replace existing block instead of duplicating it

Without this one has to resort to a workaround, such as using `python-yq` to remove the existing stanza from atlantis.yaml before partial generation.  Here are some performance measurements, showing a substantial improvement.

The measurements are for providing --filter with a single path, therefor generating/updating a single atlantis.yaml block.

1.	Old version with yq remove workaround 
	21.53s user 1.41s system 91% cpu 25.040 total
	
2.	New version with yq remove workaround 
	22.74s user 1.59s system 92% cpu 26.190 total

3.	New version without workaround 
	**2.57s user 1.12s system 70% cpu 5.244 total**

## Security Implications

- _[none]_

## System Availability

- _[none]_
