### PR TITLE
fix: parsing json files

### DIFF
--- a/cmd/golden/envhcl_allchilds.yaml
+++ b/cmd/golden/envhcl_allchilds.yaml
@@ -193,6 +193,15 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
+    - ../someRandomDir/terragrunt.hcl
+  dir: hcl_json/json_expanded
+  workflow: terragruntjson  
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
     - ../terragrunt.hcl

--- a/cmd/golden/envhcl_externalchilds.yaml
+++ b/cmd/golden/envhcl_externalchilds.yaml
@@ -193,6 +193,15 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../terragrunt.hcl
+    - ../someRandomDir/terragrunt.hcl
+  dir: hcl_json/json_expanded
+  workflow: terragruntjson  
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
     - '**/*.hcl'
     - '**/*.tf*'
     - ../terragrunt.hcl

--- a/test_examples/hcl_json/json_expanded/terragrunt.hcl.json
+++ b/test_examples/hcl_json/json_expanded/terragrunt.hcl.json
@@ -1,0 +1,38 @@
+{
+  "include": [
+    {
+      "": [
+        {
+            "path": "${find_in_parent_folders()}"
+        }
+      ]
+    }
+  ],  
+  "terraform": [
+      {
+        "source": "git::https://github.com/"
+      }
+    ],
+    "locals": {
+      "atlantis_workflow": "terragruntjson"
+    },
+    "dependency": [
+      {
+        "project": [
+          {
+            "config_path": "${get_parent_terragrunt_dir()}/someRandomDir"
+          }
+        ]
+      }
+    ],
+    "inputs": {
+      "autoscaler_name": "mig-autoscaler",
+      "autoscaling_mode": "ON",
+      "cooldown_period": 60,
+      "profile": "cy",
+      "project_id": "${dependency.project.outputs.project_id}",
+      "region": "asia-east1",
+      "target_size": 2,
+      "update_policy": []
+    }
+  }

--- a/test_examples/hcl_json/terragrunt.hcl
+++ b/test_examples/hcl_json/terragrunt.hcl
@@ -1,0 +1,12 @@
+remote_state {
+  backend = "gcs"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "skip"
+  }
+  config = {
+    bucket                      = "magical-iac-configuration"
+    prefix                      = "terragrunt/${path_relative_to_include()}"
+    project                     = "mars-007"
+  }
+}


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- [Issue#244](https://github.com/transcend-io/terragrunt-atlantis-config/issues/244)
- [Issue#243](https://github.com/transcend-io/terragrunt-atlantis-config/issues/243)
- [Terragrunt Issue#1951](https://github.com/gruntwork-io/terragrunt/issues/1951)

## Description

- Workaround to support `.hcl.json` files. 
- Added test cases with .hcl.json` files. 
- Issue: Repositories with `.hcl.json` files throw following error: 
 
```file_name.hcl.json:1,1-2: Argument or block definition required; An argument or block definition is required here.```

- Fix: Skip calling [updateBareIncludeBlock](https://github.com/transcend-io/terragrunt-atlantis-config/blob/master/cmd/parse_hcl.go#L74) function for `.hcl.json` file formats, which in-turn skips usage of hclWrite library for hcl objects generated from `.hcl.json` files.

- [RCA](https://github.com/transcend-io/terragrunt-atlantis-config/issues/244#issuecomment-1236174375)

## General Implications

- Users with `.json.hcl` file will be able to use `terragrunt atlantis config` with following condition:
   -  The include block in terragrunt should never be bare (without label). Example:
  
```json
  "include": [
    {
      "": [      "<-- This works."
        {
            "path": "${find_in_parent_folders()}"
        }
      ]
    }
  ],  
```

## Security Implications

- _[none]_

## System Availability

- _[none]_
