### PR TITLE
feat: run plan/apply for files ending with .hcl.json

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -353,6 +353,7 @@ func createProject(sourcePath string) (*AtlantisProject, error) {
 	relativeDependencies := []string{
 		"*.hcl",
 		"*.tf*",
+		"*.hcl.json",
 	}
 
 	// Add other dependencies based on their relative paths. We always want to output with Unix path separators


### PR DESCRIPTION
# Pull Request

## Related Github Issues
https://github.com/transcend-io/terragrunt-atlantis-config/issues/243

- _[none]_

## Description
The MR https://github.com/transcend-io/terragrunt-atlantis-config/pull/246 fixes the parsing of `.hcl.json` files completely but still on submiting `.hcl.json` file the plan/apply is not able to run for the files which are ending with `.hcl.json` extension since as of now only files ending with
```
"*.hcl"
"*.tf*"
```
are [allowed](https://github.com/transcend-io/terragrunt-atlantis-config/blob/8b2463cc624afd73ab2f64475b488aaef29d1aeb/cmd/generate.go#L353-356), so this MR adds `.hcl.json` as well so that plan/apply for `.hcl.json` can be run successfully.

## General Implications

- Users with `.json.hcl` file will be able to use terragrunt-atlantis-config.

TODO

## Security Implications

- _[none]_

## System Availability

- _[none]_
