### PR TITLE
inject build version into makefile from the build environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release
+name: Release
 
 on:
   push:
@@ -29,28 +29,21 @@ jobs:
           key: ubuntu-latest-1.16-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ubuntu-latest-1.16-go-
-      
-      # build binaries for all supported environments
-      - run: sudo apt update && sudo apt install -y make
-      - run: make build-all
-
-      # Create the binary checksums
-      - name: Get the version
+      - name: Get the tag version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
-      - uses: tristan-weil/ghaction-checksum-sign-artifact@v1
-        id: checksums
-        with:
-          path: 'build/${{ steps.get_version.outputs.VERSION }}/*'
-          checksum_digests: sha256,sha512
-          checksum_format: gnu
-          checksum_output: one_file_per_digest
-
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+      # build binaries for all supported environments
+      - name: Build and sign
+        run: |
+          sudo apt update && sudo apt install -y make
+          make sign
+        env:
+          TAG_VERSION: ${{ env.VERSION }}
       # Create the release
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: false
           files: |
-            build/${{ steps.get_version.outputs.VERSION }}/*
-            ${{ steps.checksums.outputs.generated-files }}
+            build/${{ env.VERSION }}/*
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-VERSION=1.16.0
+# Will use the default value beta if the environment variable doesn't exist
+TAG_VERSION?=beta
+
 PATH_BUILD=build/
 FILE_COMMAND=terragrunt-atlantis-config
 FILE_ARCH=darwin_amd64
@@ -19,9 +21,9 @@ build: clean
 	CGO_ENABLED=0 \
 	goxc \
     -bc="darwin,amd64" \
-    -pv=$(VERSION) \
+    -pv=$(TAG_VERSION) \
     -d=$(PATH_BUILD) \
-    -build-ldflags "-X main.VERSION=$(VERSION)"
+    -build-ldflags "-X main.VERSION=$(TAG_VERSION)"
 
 .PHONY: build-all
 build-all: clean
@@ -29,9 +31,9 @@ build-all: clean
 	goxc \
 	-os="$(XC_OS)" \
 	-arch="$(XC_ARCH)" \
-    -pv=$(VERSION) \
+    -pv=$(TAG_VERSION) \
     -d=$(PATH_BUILD) \
-    -build-ldflags "-X main.VERSION=$(VERSION)"
+    -build-ldflags "-X main.VERSION=$(TAG_VERSION)"
 
 .PHONY: gotestsum
 gotestsum:
@@ -47,14 +49,14 @@ test:
 
 .PHONY: version
 version:
-	@echo $(VERSION)
+	@echo $(TAG_VERSION)
 
 .PHONY: sign
 sign:  build-all
-	rm -f $(PATH_BUILD)${VERSION}/SHA256SUMS
-	shasum -a256 $(PATH_BUILD)${VERSION}/* > $(PATH_BUILD)${VERSION}/SHA256SUMS
+	rm -f $(PATH_BUILD)${TAG_VERSION}/SHA256SUMS
+	cd $(PATH_BUILD)${TAG_VERSION} && shasum -a256 * > SHA256SUMS
 
 .PHONY: install
 install:
 	install -d -m 755 '$(HOME)/bin/'
-	install $(PATH_BUILD)$(FILE_COMMAND)/$(VERSION)/$(FILE_COMMAND)_$(VERSION)_$(FILE_ARCH) '$(HOME)/bin/$(FILE_COMMAND)'
+	install $(PATH_BUILD)$(FILE_COMMAND)/$(TAG_VERSION)/$(FILE_COMMAND)_$(TAG_VERSION)_$(FILE_ARCH) '$(HOME)/bin/$(FILE_COMMAND)'


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- the current release process requires to bump the makefile internal VERSION variable before tagging

## Description

This change allow a simple tagging and the release will be created interpolating the TAG_VERSION from its CI/CD build environment.

## Security Implications

- _[none]_

## System Availability

- _[none]_
