### PR TITLE
feat: Allow multiple paths with --filter flag

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -582,17 +582,21 @@ func getAllTerragruntFiles(path string) ([]string, error) {
 		return nil, err
 	}
 
-	// If filterPath is provided, override workingPath instead of gitRoot
+	// If filterPaths is provided, override workingPath instead of gitRoot
 	// We do this here because we want to keep the relative path structure of Terragrunt files
 	// to root and just ignore the ConfigFiles
 	workingPaths := []string{path}
 
 	// filters are not working (yet) if using project hcl files (which are kind of filters by themselves)
-	if filterPath != "" && len(projectHclFiles) == 0 {
-		// get all matching folders
-		workingPaths, err = filepath.Glob(filterPath)
-		if err != nil {
-			return nil, err
+	if len(filterPaths) > 0 && len(projectHclFiles) == 0 {
+		workingPaths = []string{}
+		for _, filterPath := range filterPaths {
+			// get all matching folders
+			theseWorkingPaths, err := filepath.Glob(filterPath)
+			if err != nil {
+				return nil, err
+			}
+			workingPaths = append(workingPaths, theseWorkingPaths...)
 		}
 	}
 
@@ -903,7 +907,7 @@ var createWorkspace bool
 var createProjectName bool
 var defaultTerraformVersion string
 var defaultWorkflow string
-var filterPath string
+var filterPaths []string
 var outputPath string
 var preserveWorkflows bool
 var preserveProjects bool
@@ -946,7 +950,7 @@ func init() {
 	generateCmd.PersistentFlags().StringVar(&defaultWorkflow, "workflow", "", "Name of the workflow to be customized in the atlantis server. Default is to not set")
 	generateCmd.PersistentFlags().StringSliceVar(&defaultApplyRequirements, "apply-requirements", []string{}, "Requirements that must be satisfied before `atlantis apply` can be run. Currently the only supported requirements are `approved` and `mergeable`. Can be overridden by locals")
 	generateCmd.PersistentFlags().StringVar(&outputPath, "output", "", "Path of the file where configuration will be generated. Default is not to write to file")
-	generateCmd.PersistentFlags().StringVar(&filterPath, "filter", "", "Path or glob expression to the directory you want scope down the config for. Default is all files in root")
+	generateCmd.PersistentFlags().StringSliceVar(&filterPaths, "filter", []string{}, "Comma-separated paths or glob expressions to the directories you want scope down the config for. Default is all files in root.")
 	generateCmd.PersistentFlags().StringVar(&gitRoot, "root", pwd, "Path to the root directory of the git repo you want to build config for. Default is current dir")
 	generateCmd.PersistentFlags().StringVar(&defaultTerraformVersion, "terraform-version", "", "Default terraform version to specify for all modules. Can be overriden by locals")
 	generateCmd.PersistentFlags().Int64Var(&numExecutors, "num-executors", 15, "Number of executors used for parallel generation of projects. Default is 15")

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -36,7 +37,7 @@ func resetForRun() error {
 	preserveWorkflows = true
 	preserveProjects = true
 	defaultWorkflow = ""
-	filterPath = ""
+	filterPaths = []string{}
 	outputPath = ""
 	defaultTerraformVersion = ""
 	defaultApplyRequirements = []string{}
@@ -375,7 +376,7 @@ func TestPreservingOldProjects(t *testing.T) {
     - '*.hcl'
     - '*.tf*'
   dir: someDir
-  name: projectFromPreviousRun 
+  name: projectFromPreviousRun
 `)
 	ioutil.WriteFile(filename, contents, 0644)
 
@@ -457,6 +458,21 @@ func TestFilterFlagWithInfraLiveNonProd(t *testing.T) {
 		filepath.Join("..", "test_examples", "terragrunt-infrastructure-live-example"),
 		"--filter",
 		filepath.Join("..", "test_examples", "terragrunt-infrastructure-live-example", "non-prod"),
+	})
+}
+
+func TestFilterFlagWithInfraLiveProdAndNonProd(t *testing.T) {
+	runTest(t, filepath.Join("golden", "filterInfraLiveProdAndNonProd.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "terragrunt-infrastructure-live-example"),
+		"--filter",
+		strings.Join(
+			[]string{
+				filepath.Join("..", "test_examples", "terragrunt-infrastructure-live-example", "non-prod"),
+				filepath.Join("..", "test_examples", "terragrunt-infrastructure-live-example", "prod"),
+			},
+			",",
+		),
 	})
 }
 

--- a/cmd/golden/filterInfraLiveProdAndNonProd.yaml
+++ b/cmd/golden/filterInfraLiveProdAndNonProd.yaml
@@ -1,0 +1,71 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+  - autoplan:
+      enabled: false
+      when_modified:
+        - "*.hcl"
+        - "*.tf*"
+        - ../../../../terragrunt.hcl
+        - ../../../../_envcommon/mysql.hcl
+        - ../../../account.hcl
+        - ../../region.hcl
+        - ../env.hcl
+    dir: non-prod/us-east-1/qa/mysql
+  - autoplan:
+      enabled: false
+      when_modified:
+        - "*.hcl"
+        - "*.tf*"
+        - ../../../../terragrunt.hcl
+        - ../../../../_envcommon/webserver-cluster.hcl
+        - ../../../account.hcl
+        - ../../region.hcl
+        - ../env.hcl
+    dir: non-prod/us-east-1/qa/webserver-cluster
+  - autoplan:
+      enabled: false
+      when_modified:
+        - "*.hcl"
+        - "*.tf*"
+        - ../../../../terragrunt.hcl
+        - ../../../../_envcommon/mysql.hcl
+        - ../../../account.hcl
+        - ../../region.hcl
+        - ../env.hcl
+    dir: non-prod/us-east-1/stage/mysql
+  - autoplan:
+      enabled: false
+      when_modified:
+        - "*.hcl"
+        - "*.tf*"
+        - ../../../../terragrunt.hcl
+        - ../../../../_envcommon/webserver-cluster.hcl
+        - ../../../account.hcl
+        - ../../region.hcl
+        - ../env.hcl
+    dir: non-prod/us-east-1/stage/webserver-cluster
+  - autoplan:
+      enabled: false
+      when_modified:
+        - "*.hcl"
+        - "*.tf*"
+        - ../../../../terragrunt.hcl
+        - ../../../../_envcommon/mysql.hcl
+        - ../../../account.hcl
+        - ../../region.hcl
+        - ../env.hcl
+    dir: prod/us-east-1/prod/mysql
+  - autoplan:
+      enabled: false
+      when_modified:
+        - "*.hcl"
+        - "*.tf*"
+        - ../../../../terragrunt.hcl
+        - ../../../../_envcommon/webserver-cluster.hcl
+        - ../../../account.hcl
+        - ../../region.hcl
+        - ../env.hcl
+    dir: prod/us-east-1/prod/webserver-cluster
+version: 3


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- _[none]_

## Description

Update the type of the --filter flag so multiple paths or glob expressions can be passed as a comma-separated list.

## Security Implications

- _[none]_

## System Availability

- _[none]_
