### PR TITLE
Migrate to Gox for cross-compilation to enable ARM64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           go-version: '^1.16'
 
       # Install external go modules before cloning
-      - run: go install github.com/laher/goxc@latest
+      - run: go install github.com/mitchellh/gox@latest
 
       # Checkout code
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
       
       # build binaries for all supported environments
       - run: sudo apt update && sudo apt install -y make
-      - run: make build-all
+      - run: make archives
 
       # Create the binary checksums
       - name: Get the version

--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,47 @@
 VERSION=1.16.0
-PATH_BUILD=build/
 FILE_COMMAND=terragrunt-atlantis-config
-FILE_ARCH=darwin_amd64
+DIR_BUILD=./build
+PATH_BUILD=${DIR_BUILD}/${FILE_COMMAND}/${VERSION}
+PATTERN_BUILD=${PATH_BUILD}/${FILE_COMMAND}_${VERSION}_{{.OS}}_{{.Arch}}
+
+SHELL = bash
+
+ifeq ($(OS),Windows_NT) 
+	UNAME=windows
+else
+	UNAME=$(shell uname | tr '[:upper:]' '[:lower:]')
+endif
+
+ARCH = amd64
+FILE_ARCH=$(UNAME)_$(ARCH)
+
 S3_BUCKET_NAME=cloudfront-origin-homebrew-tap-transcend-io
 PROFILE=transcend-prod
 
 # Determine the arch/os combos we're building for
-XC_ARCH=amd64 arm
-XC_OS=linux darwin windows
+XC_OSARCH=linux/amd64 linux/arm darwin/amd64 darwin/arm64 windows/amd64 windows/arm64 linux/arm64
+
+ARCHIVE_FILES = README.md
 
 .PHONY: clean
 clean:
-	rm -rf ./build
+	rm -rf ${DIR_BUILD}
 	rm -rf '$(HOME)/bin/$(FILE_COMMAND)'
 
 .PHONY: build
 build: clean
-	CGO_ENABLED=0 \
-	goxc \
-    -bc="darwin,amd64" \
-    -pv=$(VERSION) \
-    -d=$(PATH_BUILD) \
-    -build-ldflags "-X main.VERSION=$(VERSION)"
+	gox \
+		-os="$(UNAME)" \
+		-arch="$(ARCH)" \
+		-output="$(PATTERN_BUILD)" \
+		-ldflags "-X main.VERSION=$(VERSION)"
 
 .PHONY: build-all
 build-all: clean
-	CGO_ENABLED=0 \
-	goxc \
-	-os="$(XC_OS)" \
-	-arch="$(XC_ARCH)" \
-    -pv=$(VERSION) \
-    -d=$(PATH_BUILD) \
-    -build-ldflags "-X main.VERSION=$(VERSION)"
+	gox \
+		-osarch="$(XC_OSARCH)" \
+		-output="$(PATTERN_BUILD)" \
+		-ldflags "-X main.VERSION=$(VERSION)"
 
 .PHONY: gotestsum
 gotestsum:
@@ -50,11 +60,32 @@ version:
 	@echo $(VERSION)
 
 .PHONY: sign
-sign:  build-all
-	rm -f $(PATH_BUILD)${VERSION}/SHA256SUMS
-	shasum -a256 $(PATH_BUILD)${VERSION}/* > $(PATH_BUILD)${VERSION}/SHA256SUMS
+sign: archives
+	rm -f ${DIR_BUILD}/$(VERSION)/SHA256SUMS
+	cd ${DIR_BUILD}/${VERSION} && shasum -a256 * > SHA256SUMS
 
 .PHONY: install
 install:
 	install -d -m 755 '$(HOME)/bin/'
-	install $(PATH_BUILD)$(FILE_COMMAND)/$(VERSION)/$(FILE_COMMAND)_$(VERSION)_$(FILE_ARCH) '$(HOME)/bin/$(FILE_COMMAND)'
+	install $(PATH_BUILD)/$(FILE_COMMAND)_$(VERSION)_$(FILE_ARCH) '$(HOME)/bin/$(FILE_COMMAND)'
+
+.PHONY: archives
+archives: build-all
+	mkdir -p build/$(VERSION) build/tmp
+
+	for file in $(PATH_BUILD)/*; do \
+		base=$$(basename $$file .exe); \
+		case $$file in \
+			*darwin* | *windows*) \
+				mkdir -p ${DIR_BUILD}/tmp/$$base; \
+				cp $(ARCHIVE_FILES) $$file ${DIR_BUILD}/tmp/$$base; \
+				cd ${DIR_BUILD}/tmp && zip -r ../$(VERSION)/$$base.zip $$base && cd ../..; \
+				rm -rf ${DIR_BUILD}/tmp/$$base; \
+				;; \
+			*) \
+				tar -zcvf ./build/$(VERSION)/$$base.tar.gz --transform "s/^/$$base\//" -C . $(ARCHIVE_FILES) -C $$(dirname $$file) $$base; \
+			;; \
+		esac \
+	done \
+
+	rm -rf ${DIR_BUILD}/tmp


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- _[none]_

## Description

This enables us to build for platforms such as Apple Silicon, which was the main motivation for the change.
Goxc's doesn't support this:

```
[goxc] 2023/02/09 01:34:10 WARNING: Architecture 'arm64' is unsupported
```
and its repository has been in read-only mode since June 2022

Since Gox is a much simpler project, it doesn't support packaging zip and tar archives. Implement this ourselves, while maintaining archive internal paths.

## Security Implications

- _[none]_

## System Availability

- _[none]_
