### PR TITLE
Split on the first = only in env vars

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -32,7 +32,7 @@ func getEnvs() map[string]string {
 	m := make(map[string]string)
 
 	for _, env := range envs {
-		results := strings.Split(env, "=")
+		results := strings.SplitN(env, "=", 1)
 		m[results[0]] = results[1]
 	}
 


### PR DESCRIPTION

# Pull Request

## Related Github Issues

- _[none]_

## Description

If your env var value contains an `=`, this code will cut off anything after the `=` in your value.

Env var keys are not allowed to contain an `=`, so restricting this to a single split should be safe.

## Security Implications

- _[none]_

## System Availability

- _[none]_
