### PR TITLE
feat: Add new flag: autoplan-file-list

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then, make sure `terragrunt-atlantis-config` is present on your Atlantis server.
 
 ```hcl
 variable "terragrunt_atlantis_config_version" {
-  default = "1.16.0"
+  default = "1.17.0"
 }
 
 build {
@@ -112,26 +112,27 @@ If you specify `extra_atlantis_dependencies` in the parent Terragrunt module, th
 
 One way to customize the behavior of this module is through CLI flag values passed in at runtime. These settings will apply to all modules.
 
-| Flag Name                    | Description                                                                                                                                                                     | Default Value     |
-|------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------|
-| `--autoplan`                 | The default value for autoplan settings. Can be overriden by locals.                                                                                                            | false             |
-| `--automerge`                | Enables the automerge setting for a repo.                                                                                                                                       | false             |
-| `--cascade-dependencies`     | When true, dependencies will cascade, meaning that a module will be declared to depend not only on its dependencies, but all dependencies of its dependencies all the way down. | true              |
-| `--ignore-parent-terragrunt` | Ignore parent Terragrunt configs (those which don't reference a terraform module).<br>In most cases, this should be set to `true`                                               | true              |
-| `--parallel`                 | Enables `plan`s and `apply`s to happen in parallel. Will typically be used with `--create-workspace`                                                                            | true              |
-| `--create-workspace`         | Use different auto-generated workspace for each project. Default is use default workspace for everything                                                                        | false             |
-| `--create-project-name`      | Add different auto-generated name for each project                                                                                                                              | false             |
-| `--preserve-workflows`       | Preserves workflows from old output files. Useful if you want to define your workflow definitions on the client side                                                            | true              |
-| `--preserve-projects`        | Preserves projects from old output files. Useful for incremental builds using `--filter`                                                                                        | false             |
-| `--workflow`                 | Name of the workflow to be customized in the atlantis server. If empty, will be left out of output                                                                              | ""                |
-| `--apply-requirements`       | Requirements that must be satisfied before `atlantis apply` can be run. Currently the only supported requirements are `approved` and `mergeable`. Can be overridden by locals   | []                |
-| `--output`                   | Path of the file where configuration will be generated. Typically, you want a file named "atlantis.yaml". Default is to write to `stdout`.                                      | ""                |
-| `--root`                     | Path to the root directory of the git repo you want to build config for.                                                                                                        | current directory |
-| `--terraform-version`        | Default terraform version to specify for all modules. Can be overriden by locals                                                                                                | ""                |
-| `--ignore-dependency-blocks` | When true, dependencies found in `dependency` and `dependencies` blocks will be ignored                                                                                         | false             |
-| `--filter`                   | Path or glob expression to the directory you want scope down the config for. Default is all files in root                                                                       | ""                |
-| `--num-executors`            | Number of executors used for parallel generation of projects. Default is 15                                                                                                     | 15                |
-| `--execution-order-groups`   | Computes execution_order_group for projects                                                                                                                                     | false             |
+| Flag Name                    | Description                                                                                                                                                                     | Default Value      |
+|------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|
+| `--autoplan`                 | The default value for autoplan settings. Can be overriden by locals.                                                                                                            | false              |
+| `--automerge`                | Enables the automerge setting for a repo.                                                                                                                                       | false              |
+| `--autoplan-file-list`       | List of file patterns that Atlantis will use to check if a directory contains modified files that should trigger project planning.                                              | ["*.hcl", "*.tf*"] |
+| `--cascade-dependencies`     | When true, dependencies will cascade, meaning that a module will be declared to depend not only on its dependencies, but all dependencies of its dependencies all the way down. | true               |
+| `--ignore-parent-terragrunt` | Ignore parent Terragrunt configs (those which don't reference a terraform module).<br>In most cases, this should be set to `true`                                               | true               |
+| `--parallel`                 | Enables `plan`s and `apply`s to happen in parallel. Will typically be used with `--create-workspace`                                                                            | true               |
+| `--create-workspace`         | Use different auto-generated workspace for each project. Default is use default workspace for everything                                                                        | false              |
+| `--create-project-name`      | Add different auto-generated name for each project                                                                                                                              | false              |
+| `--preserve-workflows`       | Preserves workflows from old output files. Useful if you want to define your workflow definitions on the client side                                                            | true               |
+| `--preserve-projects`        | Preserves projects from old output files. Useful for incremental builds using `--filter`                                                                                        | false              |
+| `--workflow`                 | Name of the workflow to be customized in the atlantis server. If empty, will be left out of output                                                                              | ""                 |
+| `--apply-requirements`       | Requirements that must be satisfied before `atlantis apply` can be run. Currently the only supported requirements are `approved` and `mergeable`. Can be overridden by locals   | []                 |
+| `--output`                   | Path of the file where configuration will be generated. Typically, you want a file named "atlantis.yaml". Default is to write to `stdout`.                                      | ""                 |
+| `--root`                     | Path to the root directory of the git repo you want to build config for.                                                                                                        | current directory  |
+| `--terraform-version`        | Default terraform version to specify for all modules. Can be overriden by locals                                                                                                | ""                 |
+| `--ignore-dependency-blocks` | When true, dependencies found in `dependency` and `dependencies` blocks will be ignored                                                                                         | false              |
+| `--filter`                   | Path or glob expression to the directory you want scope down the config for. Default is all files in root                                                                       | ""                 |
+| `--num-executors`            | Number of executors used for parallel generation of projects. Default is 15                                                                                                     | 15                 |
+| `--execution-order-groups`   | Computes execution_order_group for projects                                                                                                                                     | false              |
 
 ## Project generation
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -350,10 +350,7 @@ func createProject(sourcePath string) (*AtlantisProject, error) {
 	}
 
 	// All dependencies depend on their own .hcl file, and any tf files in their directory
-	relativeDependencies := []string{
-		"*.hcl",
-		"*.tf*",
-	}
+	relativeDependencies := autoplanFileList
 
 	// Add other dependencies based on their relative paths. We always want to output with Unix path separators
 	for _, dependencyPath := range dependencies {
@@ -895,6 +892,7 @@ func main(cmd *cobra.Command, args []string) error {
 var gitRoot string
 var autoPlan bool
 var autoMerge bool
+var autoplanFileList []string
 var ignoreParentTerragrunt bool
 var createParentProject bool
 var ignoreDependencyBlocks bool
@@ -935,6 +933,7 @@ func init() {
 	generateCmd.PersistentFlags().BoolVar(&autoPlan, "autoplan", false, "Enable auto plan. Default is disabled")
 	generateCmd.PersistentFlags().BoolVar(&autoMerge, "automerge", false, "Enable auto merge. Default is disabled")
 	generateCmd.PersistentFlags().BoolVar(&ignoreParentTerragrunt, "ignore-parent-terragrunt", true, "Ignore parent terragrunt configs (those which don't reference a terraform module). Default is enabled")
+	generateCmd.PersistentFlags().StringSliceVar(&autoplanFileList, "autoplan-file-list", []string{"*.hcl", "*.tf*"}, "List of file patterns that Atlantis will use to check if a directory contains modified files that should trigger project planning")
 	generateCmd.PersistentFlags().BoolVar(&createParentProject, "create-parent-project", false, "Create a project for the parent terragrunt configs (those which don't reference a terraform module). Default is disabled")
 	generateCmd.PersistentFlags().BoolVar(&ignoreDependencyBlocks, "ignore-dependency-blocks", false, "When true, dependencies found in `dependency` blocks will be ignored")
 	generateCmd.PersistentFlags().BoolVar(&parallel, "parallel", true, "Enables plans and applys to happen in parallel. Default is enabled")

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -27,6 +27,7 @@ func resetForRun() error {
 	gitRoot = pwd
 	autoPlan = false
 	autoMerge = false
+	autoplanFileList = []string{"*.hcl", "*.tf*"}
 	cascadeDependencies = true
 	ignoreParentTerragrunt = true
 	ignoreDependencyBlocks = false
@@ -622,5 +623,13 @@ func TestWithExecutionOrderGroups(t *testing.T) {
 		"--root",
 		filepath.Join("..", "test_examples", "chained_dependencies"),
 		"--execution-order-groups",
+	})
+}
+
+func TestAutoplanFileList(t *testing.T) {
+	runTest(t, filepath.Join("golden", "autoplan_file_list.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "basic_module"),
+		"--autoplan-file-list=*.hcl,*.tf*,*.yaml,*.yml",
 	})
 }

--- a/cmd/golden/autoplan_file_list.yaml
+++ b/cmd/golden/autoplan_file_list.yaml
@@ -1,0 +1,13 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '*.yaml'
+    - '*.yml'
+  dir: .
+version: 3

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import "github.com/transcend-io/terragrunt-atlantis-config/cmd"
 // This variable is set at build time using -ldflags parameters.
 // But we still set a default here for those using plain `go get` downloads
 // For more info, see: http://stackoverflow.com/a/11355611/483528
-var VERSION string = "1.16.0"
+var VERSION string = "1.17.0"
 
 func main() {
 	cmd.Execute(VERSION)


### PR DESCRIPTION
# Pull Request

## Description

Add new flag `autoplan-file-list`, it mirrors how [Atlantis' autoplan-file-list](https://www.runatlantis.io/docs/server-configuration.html#autoplan-file-list) works. As Atlantis' flag doesnt come into effect when custom atlantis.yaml is generated, the only way to have it is by adding to `terragrunt-atlantis-config`.
