### PR TITLE
Replace deprecated ioutil calls

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 
@@ -70,7 +70,7 @@ type AutoplanConfig struct {
 // in to preserve some parts of the old config
 func readOldConfig() (*AtlantisConfig, error) {
 	// The old file not existing is not an error, as it should not exist on the very first run
-	bytes, err := ioutil.ReadFile(outputPath)
+	bytes, err := os.ReadFile(outputPath)
 	if err != nil {
 		log.Info("Could not find an old config file. Starting from scratch")
 		return nil, nil

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -17,7 +17,6 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -880,7 +879,7 @@ func main(cmd *cobra.Command, args []string) error {
 
 	// Write output
 	if len(outputPath) != 0 {
-		ioutil.WriteFile(outputPath, []byte(yamlString), 0644)
+		os.WriteFile(outputPath, []byte(yamlString), 0644)
 	} else {
 		log.Println(yamlString)
 	}
@@ -958,5 +957,5 @@ func RunWithFlags(filename string, args []string) ([]byte, error) {
 	rootCmd.SetArgs(args)
 	rootCmd.Execute()
 
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename)
 }

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -74,7 +73,7 @@ func runTest(t *testing.T, goldenFile string, args []string) {
 		return
 	}
 
-	goldenContentsBytes, err := ioutil.ReadFile(goldenFile)
+	goldenContentsBytes, err := os.ReadFile(goldenFile)
 	goldenContents := &AtlantisConfig{}
 	yaml.Unmarshal(goldenContentsBytes, goldenContents)
 	if err != nil {
@@ -331,7 +330,7 @@ func TestPreservingOldWorkflows(t *testing.T) {
       steps:
       - run: terragrunt plan -no-color -out $PLANFILE
 `)
-	ioutil.WriteFile(filename, contents, 0644)
+	os.WriteFile(filename, contents, 0644)
 
 	content, err := RunWithFlags(filename, []string{
 		"generate",
@@ -345,7 +344,7 @@ func TestPreservingOldWorkflows(t *testing.T) {
 		return
 	}
 
-	goldenContents, err := ioutil.ReadFile(filepath.Join("golden", "oldWorkflowsPreserved.yaml"))
+	goldenContents, err := os.ReadFile(filepath.Join("golden", "oldWorkflowsPreserved.yaml"))
 	if err != nil {
 		t.Error("Failed to read golden file")
 		return
@@ -377,7 +376,7 @@ func TestPreservingOldProjects(t *testing.T) {
   dir: someDir
   name: projectFromPreviousRun 
 `)
-	ioutil.WriteFile(filename, contents, 0644)
+	os.WriteFile(filename, contents, 0644)
 
 	content, err := RunWithFlags(filename, []string{
 		"generate",
@@ -392,7 +391,7 @@ func TestPreservingOldProjects(t *testing.T) {
 		return
 	}
 
-	goldenContents, err := ioutil.ReadFile(filepath.Join("golden", "oldProjectsPreserved.yaml"))
+	goldenContents, err := os.ReadFile(filepath.Join("golden", "oldProjectsPreserved.yaml"))
 	if err != nil {
 		t.Error("Failed to read golden file")
 		return


### PR DESCRIPTION
Replacing deprecated `ioutil` calls with the respective `os` counterparts.

Depends on #307.