### PR TITLE
Add ability to define extra deps for local modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.21.6
+VERSION=1.22.0
 PATH_BUILD=build/
 FILE_COMMAND=terragrunt-atlantis-config
 FILE_ARCH=$(shell go env GOOS)_$(shell go env GOARCH)

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -201,6 +201,17 @@ func getDependencies(path string, terragruntOptions *options.TerragruntOptions) 
 				// Remove the prefix so we have a valid filesystem path
 				parsedSource = strings.TrimPrefix(parsedSource, "file://")
 
+				moduleTerragruntFilePath := filepath.Join(parsedSource, "extra.hcl")
+				if _, err := os.Stat(moduleTerragruntFilePath); err == nil {
+					extraLocals, err := parseLocals(moduleTerragruntFilePath, terragruntOptions, nil)
+					if err != nil {
+						return nil, err
+					}
+					for _, extraDep := range extraLocals.ExtraAtlantisDependencies {
+						dependencies = append(dependencies, filepath.Join(parsedSource, extraDep))
+					}
+				}
+
 				dependencies = append(dependencies, filepath.Join(parsedSource, "*.tf*"))
 
 				ls, err := parseTerraformLocalModuleSource(parsedSource)

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -171,6 +171,12 @@ func TestLocalTerraformModuleSource(t *testing.T) {
 		filepath.Join("..", "test_examples", "local_terraform_module_source"),
 	})
 }
+func TestLocalTerraformModuleExtraSource(t *testing.T) {
+	runTest(t, filepath.Join("golden", "local_terraform_module_extra.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "local_terraform_module_extra_source"),
+	})
+}
 
 func TestLocalTerraformAbsModuleSource(t *testing.T) {
 	runTest(t, filepath.Join("golden", "local_terraform_abs_module.yaml"), []string{

--- a/cmd/golden/envhcl_allchilds.yaml
+++ b/cmd/golden/envhcl_allchilds.yaml
@@ -227,6 +227,16 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../root-module/*.py
+    - ../root-module/src/*
+    - ../root-module/*.tf*
+    - ../terraform-module/*.tf*
+  dir: local_terraform_module_extra_source/terragrunt-module
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
     - ../root-module/*.tf*
     - ../terraform-module/*.tf*
   dir: local_terraform_module_source/terragrunt-module

--- a/cmd/golden/envhcl_externalchilds.yaml
+++ b/cmd/golden/envhcl_externalchilds.yaml
@@ -220,6 +220,16 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - ../root-module/*.py
+    - ../root-module/src/*
+    - ../root-module/*.tf*
+    - ../terraform-module/*.tf*
+  dir: local_terraform_module_extra_source/terragrunt-module
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
     - ../root-module/*.tf*
     - ../terraform-module/*.tf*
   dir: local_terraform_module_source/terragrunt-module

--- a/cmd/golden/local_terraform_module_extra.yaml
+++ b/cmd/golden/local_terraform_module_extra.yaml
@@ -1,0 +1,15 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../root-module/*.py
+    - ../root-module/src/*
+    - ../root-module/*.tf*
+    - ../terraform-module/*.tf*
+  dir: terragrunt-module
+version: 3

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import "github.com/transcend-io/terragrunt-atlantis-config/cmd"
 // This variable is set at build time using -ldflags parameters.
 // But we still set a default here for those using plain `go get` downloads
 // For more info, see: http://stackoverflow.com/a/11355611/483528
-var VERSION string = "1.17.4"
+var VERSION string = "1.22.0"
 
 func main() {
 	cmd.Execute(VERSION)

--- a/test_examples/local_terraform_module_extra_source/root-module/extra.hcl
+++ b/test_examples/local_terraform_module_extra_source/root-module/extra.hcl
@@ -1,0 +1,7 @@
+locals {
+    atlantis_skip = true
+    extra_atlantis_dependencies = [
+        "*.py",
+        "src/*"
+    ]
+}

--- a/test_examples/local_terraform_module_extra_source/root-module/main.tf
+++ b/test_examples/local_terraform_module_extra_source/root-module/main.tf
@@ -1,0 +1,3 @@
+module "module_1" {
+  source = "../terraform-module"
+}

--- a/test_examples/local_terraform_module_extra_source/terraform-module/main.tf
+++ b/test_examples/local_terraform_module_extra_source/terraform-module/main.tf
@@ -1,0 +1,3 @@
+resource "some_resource" "some_name" {
+  foo = "bar"
+}

--- a/test_examples/local_terraform_module_extra_source/terragrunt-module/terragrunt.hcl
+++ b/test_examples/local_terraform_module_extra_source/terragrunt-module/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "../root-module"
+}
+
+inputs = {
+  foo = "bar"
+}


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- #243

## Description

I'm looking to add the ability to also trigger a run based on non-terragrunt files in local modules referenced via `source` in the `terraform` block in `terragrunt.hcl`.
Especially the filename is up for discussion. It seems obvious to name it terragrunt.hcl, but I'm not sure if I got an overview of all possible implications of adding such a file local modules that should not be applied directly.

Looking for feedback, it seems to be working for us in a small experimental run.

## Security Implications

- _[none]_

## System Availability

- _[none]_
