### PR TITLE
add depends_on; fix execution_order_group 0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then, make sure `terragrunt-atlantis-config` is present on your Atlantis server.
 
 ```hcl
 variable "terragrunt_atlantis_config_version" {
-  default = "1.17.9"
+  default = "1.18.0"
 }
 
 build {
@@ -132,6 +132,7 @@ One way to customize the behavior of this module is through CLI flag values pass
 | `--filter`                   | Path or glob expression to the directory you want scope down the config for. Default is all files in root                                                                       | ""                |
 | `--num-executors`            | Number of executors used for parallel generation of projects. Default is 15                                                                                                     | 15                |
 | `--execution-order-groups`   | Computes execution_order_group for projects                                                                                                                                     | false             |
+| `--depends-on            `   | Computes depends_on for projects. Project names are required.                                                                                                                   | false             |
 
 ## Project generation
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ One way to customize the behavior of this module is through CLI flag values pass
 | `--filter`                   | Path or glob expression to the directory you want scope down the config for. Default is all files in root                                                                       | ""                |
 | `--num-executors`            | Number of executors used for parallel generation of projects. Default is 15                                                                                                     | 15                |
 | `--execution-order-groups`   | Computes execution_order_group for projects                                                                                                                                     | false             |
-| `--depends-on            `   | Computes depends_on for projects. Project names are required.                                                                                                                   | false             |
+| `--depends-on`               | Computes depends_on for projects. Project names are required.                                                                                                                   | false             |
 
 ## Project generation
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -54,7 +54,10 @@ type AtlantisProject struct {
 	ApplyRequirements *[]string `json:"apply_requirements,omitempty"`
 
 	// Atlantis use ExecutionOrderGroup for sort projects before applying/planning
-	ExecutionOrderGroup int `json:"execution_order_group,omitempty"`
+	ExecutionOrderGroup *int `json:"execution_order_group,omitempty"`
+
+	// Atlantis uses DependsOn to define dependencies between projects
+	DependsOn []string `json:"depends_on,omitempty"`
 }
 
 // Autoplan settings for which plans affect other plans

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -828,7 +828,7 @@ func main(cmd *cobra.Command, args []string) error {
 				dependsOnList := []string{}
 				// choose order group based on dependencies
 				for _, dep := range project.Autoplan.WhenModified {
-					depPath := filepath.Dir(filepath.Join(project.Dir, dep))
+					depPath := filepath.ToSlash(filepath.Dir(filepath.Join(project.Dir, dep)))
 					if depPath == project.Dir {
 						// skip dependency on oneself
 						continue

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -43,6 +43,8 @@ func resetForRun() error {
 	createHclProjectChilds = false
 	createHclProjectExternalChilds = true
 	useProjectMarkers = false
+	executionOrderGroups = false
+	dependsOn = false
 
 	return nil
 }
@@ -621,5 +623,24 @@ func TestWithExecutionOrderGroups(t *testing.T) {
 		"--root",
 		filepath.Join("..", "test_examples", "chained_dependencies"),
 		"--execution-order-groups",
+	})
+}
+
+func TestWithExecutionOrderGroupsAndDependsOn(t *testing.T) {
+	runTest(t, filepath.Join("golden", "withExecutionOrderGroupsAndDependsOn.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "chained_dependencies"),
+		"--execution-order-groups",
+		"--depends-on",
+		"--create-project-name",
+	})
+}
+
+func TestWithDependsOn(t *testing.T) {
+	runTest(t, filepath.Join("golden", "withDependsOn.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "chained_dependencies"),
+		"--depends-on",
+		"--create-project-name",
 	})
 }

--- a/cmd/golden/withDependsOn.yaml
+++ b/cmd/golden/withDependsOn.yaml
@@ -1,0 +1,45 @@
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: dependency
+  name: dependency
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../dependency/terragrunt.hcl
+  depends_on:
+  - dependency
+  dir: depender
+  name: depender
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../depender/terragrunt.hcl
+    - ../dependency/terragrunt.hcl
+    - nested/terragrunt.hcl
+  depends_on:
+  - depender
+  - dependency
+  - depender_on_depender_nested
+  dir: depender_on_depender
+  name: depender_on_depender
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../dependency/terragrunt.hcl
+  depends_on:
+  - dependency
+  dir: depender_on_depender/nested
+  name: depender_on_depender_nested
+version: 3 

--- a/cmd/golden/withExecutionOrderGroups.yaml
+++ b/cmd/golden/withExecutionOrderGroups.yaml
@@ -8,6 +8,7 @@ projects:
         - '*.hcl'
         - '*.tf*'
     dir: dependency
+    execution_order_group: 0
   - autoplan:
       enabled: false
       when_modified:

--- a/cmd/golden/withExecutionOrderGroupsAndDependsOn.yaml
+++ b/cmd/golden/withExecutionOrderGroupsAndDependsOn.yaml
@@ -1,0 +1,49 @@
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: dependency
+  execution_order_group: 0
+  name: dependency
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../dependency/terragrunt.hcl
+  depends_on:
+  - dependency
+  dir: depender
+  execution_order_group: 1
+  name: depender
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../dependency/terragrunt.hcl
+  depends_on:
+  - dependency
+  dir: depender_on_depender/nested
+  execution_order_group: 1
+  name: depender_on_depender_nested
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../depender/terragrunt.hcl
+    - ../dependency/terragrunt.hcl
+    - nested/terragrunt.hcl
+  depends_on:
+  - depender
+  - dependency
+  - depender_on_depender_nested
+  dir: depender_on_depender
+  execution_order_group: 2
+  name: depender_on_depender
+version: 3

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import "github.com/transcend-io/terragrunt-atlantis-config/cmd"
 // This variable is set at build time using -ldflags parameters.
 // But we still set a default here for those using plain `go get` downloads
 // For more info, see: http://stackoverflow.com/a/11355611/483528
-var VERSION string = "1.17.9"
+var VERSION string = "1.18.0"
 
 func main() {
 	cmd.Execute(VERSION)

--- a/out
+++ b/out
@@ -1,0 +1,49 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: dependency
+  execution_order_group: 0
+  name: dependency
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../dependency/terragrunt.hcl
+  depends_on:
+  - dependency
+  dir: depender
+  execution_order_group: 1
+  name: depender
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../../dependency/terragrunt.hcl
+  depends_on:
+  - dependency
+  dir: depender_on_depender/nested
+  execution_order_group: 1
+  name: depender_on_depender_nested
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../depender/terragrunt.hcl
+    - ../dependency/terragrunt.hcl
+    - nested/terragrunt.hcl
+  depends_on:
+  - depender
+  - dependency
+  dir: depender_on_depender
+  execution_order_group: 2
+  name: depender_on_depender
+version: 3


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- #296 
- #319 

## Description

Adds functionality for `depends_on`
Fixes bug where the base execution_group (0) was not explicitly given.

## Security Implications

- _[none]_

## System Availability

- _[none]_
