### PR TITLE
Fix parsing environment variables

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -30,8 +30,8 @@ func getEnvs() map[string]string {
 	m := make(map[string]string)
 
 	for _, env := range envs {
-		results := strings.SplitN(env, "=", 1)
-		m[results[0]] = results[1]
+		name, value, _ := strings.Cut(env, "=")
+		m[name] = value
 	}
 
 	return m


### PR DESCRIPTION
# Pull Request


## Related Github Issues

- N/A
## Description
This was previously breaking tests for me locally, as well as on the CI.

It appears to me that if we were to use `SplitN`, we would have to specify the `n = 2` to get at most 2 substrings: the name and the value. However, the documentation around `SplitN` recommends we use `Cut` instead, which seems simpler.

## Security Implications

- _[none]_

## System Availability

- _[none]_
