### PR TITLE
fix: missing environment variables in dependencies

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -259,6 +259,7 @@ func getDependencies(path string, terragruntOptions *options.TerragruntOptions) 
 			depPath := dep
 			terrOpts, _ := options.NewTerragruntOptionsWithConfigPath(depPath)
 			terrOpts.OriginalTerragruntConfigPath = terragruntOptions.OriginalTerragruntConfigPath
+			terrOpts.Env = terragruntOptions.Env
 			childDeps, err := getDependencies(depPath, terrOpts)
 			if err != nil {
 				continue


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- #259 

## Description

A terragrunt file that uses `get_env("SOME_ENV_VAR")` and is a dependency to another one will get an error saying the env var does not exist. It works on files that are not a dependency.
This happens because the `getDependencies` function does not supply the environment variables to its recursive calls in this case.

## Security Implications

- _[none]_

## System Availability

- _[none]_
