### PR TITLE
1.19 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.18.0
+VERSION=1.19.0
 PATH_BUILD=build/
 FILE_COMMAND=terragrunt-atlantis-config
 FILE_ARCH=$(shell go env GOOS)_$(shell go env GOARCH)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then, make sure `terragrunt-atlantis-config` is present on your Atlantis server.
 
 ```hcl
 variable "terragrunt_atlantis_config_version" {
-  default = "1.18.0"
+  default = "1.19.0"
 }
 
 build {

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import "github.com/transcend-io/terragrunt-atlantis-config/cmd"
 // This variable is set at build time using -ldflags parameters.
 // But we still set a default here for those using plain `go get` downloads
 // For more info, see: http://stackoverflow.com/a/11355611/483528
-var VERSION string = "1.18.0"
+var VERSION string = "1.19.0"
 
 func main() {
 	cmd.Execute(VERSION)


### PR DESCRIPTION
I'll push a `v1.19.0` tag to master once this is merged in to trigger the CI. Hopefully I have permission to do that, it's been a while since the last release.

This release contains https://github.com/transcend-io/terragrunt-atlantis-config/pull/350 and some other misc changes