### PR TITLE
Make dependsOnList unique, duplicates when extra arguments are added

### DIFF
--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -204,6 +204,16 @@ func TestIgnoringTerragruntDependencies(t *testing.T) {
 	})
 }
 
+func TestTerragruntDependenciesExtraArguments(t *testing.T) {
+	runTest(t, filepath.Join("golden", "terragrunt_dependency_extra_arguments.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "terragrunt_dependency_extra_arguments"),
+		"--depends-on",
+		"--create-project-name",
+	})
+}
+
+
 func TestCustomWorkflowName(t *testing.T) {
 	runTest(t, filepath.Join("golden", "different_workflow_names.yaml"), []string{
 		"--root",

--- a/cmd/golden/envhcl_allchilds.yaml
+++ b/cmd/golden/envhcl_allchilds.yaml
@@ -789,6 +789,21 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - extra.tfvars
+  dir: terragrunt_dependency_extra_arguments/dependency
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../dependency/terragrunt.hcl
+    - ../dependency/extra.tfvars
+  dir: terragrunt_dependency_extra_arguments/depender
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
     - ../terragrunt.hcl
     - ../common/terragrunt.hcl
     - ../dependency/terragrunt.hcl

--- a/cmd/golden/envhcl_externalchilds.yaml
+++ b/cmd/golden/envhcl_externalchilds.yaml
@@ -566,6 +566,21 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+    - extra.tfvars
+  dir: terragrunt_dependency_extra_arguments/dependency
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../dependency/terragrunt.hcl
+    - ../dependency/extra.tfvars
+  dir: terragrunt_dependency_extra_arguments/depender
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
     - ../terragrunt.hcl
     - ../common/terragrunt.hcl
     - ../dependency/terragrunt.hcl

--- a/cmd/golden/terragrunt_dependency_extra_arguments.yaml
+++ b/cmd/golden/terragrunt_dependency_extra_arguments.yaml
@@ -1,0 +1,24 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - extra.tfvars
+  dir: dependency
+  name: dependency
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../dependency/terragrunt.hcl
+    - ../dependency/extra.tfvars
+  depends_on:
+  - dependency
+  dir: depender
+  name: depender
+version: 3

--- a/cmd/golden/withDependsOn.yaml
+++ b/cmd/golden/withDependsOn.yaml
@@ -27,8 +27,8 @@ projects:
     - ../dependency/terragrunt.hcl
     - nested/terragrunt.hcl
   depends_on:
-  - depender
   - dependency
+  - depender
   - depender_on_depender_nested
   dir: depender_on_depender
   name: depender_on_depender

--- a/cmd/golden/withExecutionOrderGroupsAndDependsOn.yaml
+++ b/cmd/golden/withExecutionOrderGroupsAndDependsOn.yaml
@@ -40,8 +40,8 @@ projects:
     - ../dependency/terragrunt.hcl
     - nested/terragrunt.hcl
   depends_on:
-  - depender
   - dependency
+  - depender
   - depender_on_depender_nested
   dir: depender_on_depender
   execution_order_group: 2

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 )
 
 require (
+	bitbucket.org/creachadair/stringset v0.0.14 // indirect
 	cloud.google.com/go v0.110.10 // indirect
 	cloud.google.com/go/compute v1.23.1 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
@@ -123,7 +124,7 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
-	golang.org/x/mod v0.12.0 // indirect
+	golang.org/x/mod v0.15.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.13.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+bitbucket.org/creachadair/stringset v0.0.14 h1:t1ejQyf8utS4GZV/4fM+1gvYucggZkfhb+tMobDxYOE=
+bitbucket.org/creachadair/stringset v0.0.14/go.mod h1:Ej8fsr6rQvmeMDf6CCWMWGb14H9mz8kmDgPPTdiVT0w=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -1050,6 +1052,8 @@ golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.15.0 h1:SernR4v+D55NyBH2QiEQrlBAnj1ECL6AGrA5+dPaMY8=
+golang.org/x/mod v0.15.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/test_examples/terragrunt_dependency_extra_arguments/dependency/terragrunt.hcl
+++ b/test_examples/terragrunt_dependency_extra_arguments/dependency/terragrunt.hcl
@@ -1,0 +1,13 @@
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+  extra_arguments "extra" {
+    commands = get_terraform_commands_that_need_vars()
+    optional_var_files = [
+      "${get_terragrunt_dir()}/extra.tfvars",
+    ]
+  }
+}
+
+inputs = {
+  foo = "bar"
+}

--- a/test_examples/terragrunt_dependency_extra_arguments/depender/terragrunt.hcl
+++ b/test_examples/terragrunt_dependency_extra_arguments/depender/terragrunt.hcl
@@ -1,0 +1,11 @@
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+dependency "some_dep" {
+  config_path = "../dependency"
+}
+
+inputs = {
+  foo = dependency.some_dep.outputs.some_output
+}


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- https://github.com/transcend-io/terragrunt-atlantis-config/issues/365

## Description

Making dependsOnList a set to be a unique list, to fix issues with extra_arguments and duplicating dependencies.

## Security Implications

- _[none]_

## System Availability

- _[none]_
