### PR TITLE
feat: improve error message for invalid extra atlantis dependencies

### DIFF
--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -168,6 +168,28 @@ func TestExtraDeclaredDependencies(t *testing.T) {
 	})
 }
 
+func TestNonStringErrorOnExtraDeclaredDependencies(t *testing.T) {
+	err := resetForRun()
+	if err != nil {
+		t.Error("Failed to reset default flags")
+		return
+	}
+
+	rootCmd.SetArgs([]string{
+		"generate",
+		"--root",
+		filepath.Join("..", "test_examples_errors", "extra_dependency_error"),
+	})
+	err = rootCmd.Execute()
+	
+	expectedError := "extra_atlantis_dependencies contains non-string value at position 4"
+	if err == nil || err.Error() != expectedError {
+		t.Errorf("Expected error '%s', got '%v'", expectedError, err)
+		return
+	}
+	return
+}
+
 func TestLocalTerraformModuleSource(t *testing.T) {
 	runTest(t, filepath.Join("golden", "local_terraform_module.yaml"), []string{
 		"--root",

--- a/test_examples_errors/extra_dependency_error/child/terragrunt.hcl
+++ b/test_examples_errors/extra_dependency_error/child/terragrunt.hcl
@@ -1,0 +1,15 @@
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+locals {
+  tg_config = read_terragrunt_config(find_in_parent_folders("config.hcl"))
+
+  extra_atlantis_dependencies = [
+    "some_extra_dep0",
+    "some_extra_dep1",
+    "some_extra_dep2",
+    "some_extra_dep3",
+    local.tg_config
+  ]
+}

--- a/test_examples_errors/extra_dependency_error/config.hcl
+++ b/test_examples_errors/extra_dependency_error/config.hcl
@@ -1,0 +1,3 @@
+locals {
+  aws_account_id = "111131111219"
+}


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- #266 

## Description
This PR aims to improve the error message thrown when there's an invalid extra dependency declared. Since this problem made me lose a couple of minutes last week, I decided that we can show a proper message for when there's an invalid filepath set on the `extra_atlantis_dependencies` array.

For the example I'm adding on the test cases, the message before this PR was this:
```
panic: not a string

        runtime/debug.Stack()
                /usr/local/go/src/runtime/debug/stack.go:26 +0x64
        golang.org/x/sync/singleflight.newPanicError({0x103183aa0, 0x103420890})
                /Users/brunoferreira/go/pkg/mod/golang.org/x/sync@v0.4.0/singleflight/singleflight.go:44 +0x24
        golang.org/x/sync/singleflight.(*Group).doCall.func2.1()
                /Users/brunoferreira/go/pkg/mod/golang.org/x/sync@v0.4.0/singleflight/singleflight.go:193 +0x40
        panic({0x103183aa0?, 0x103420890?})
                /usr/local/go/src/runtime/panic.go:785 +0x124
        github.com/zclconf/go-cty/cty.Value.AsString({{{0x103437198?, 0x14000052dc0?}}, {0x103217240?, 0x140006b9e00?}})
                /Users/brunoferreira/go/pkg/mod/github.com/zclconf/go-cty@v1.13.2/cty/value_ops.go:1387 +0x128
        github.com/transcend-io/terragrunt-atlantis-config/cmd.resolveLocals({{{0x103437198?, 0x140000531c0?}}, {0x103217240?, 0x140006e2420?}})
                /Users/brunoferreira/repos/terragrunt-atlantis-config/cmd/parse_locals.go:195 +0x538
        github.com/transcend-io/terragrunt-atlantis-config/cmd.parseLocals({0x14000110f80, 0x76}, 0x14000893b88, 0x0)
                /Users/brunoferreira/repos/terragrunt-atlantis-config/cmd/parse_locals.go:129 +0x254
        github.com/transcend-io/terragrunt-atlantis-config/cmd.getDependencies.func1()
                /Users/brunoferreira/repos/terragrunt-atlantis-config/cmd/generate.go:165 +0x208
        golang.org/x/sync/singleflight.(*Group).doCall.func2(0x140005cd976, 0x1400088c190, 0x1400088c101?)
                /Users/brunoferreira/go/pkg/mod/golang.org/x/sync@v0.4.0/singleflight/singleflight.go:198 +0x58
        golang.org/x/sync/singleflight.(*Group).doCall(0x103219460?, 0x140000cf2c0?, {0x14000110f80?, 0x76?}, 0x103217000?)
                /Users/brunoferreira/go/pkg/mod/golang.org/x/sync@v0.4.0/singleflight/singleflight.go:200 +0x74
        golang.org/x/sync/singleflight.(*Group).Do(0x103f28fc0, {0x14000110f80, 0x76}, 0x1400011ea38)
                /Users/brunoferreira/go/pkg/mod/golang.org/x/sync@v0.4.0/singleflight/singleflight.go:113 +0x1bc
        github.com/transcend-io/terragrunt-atlantis-config/cmd.getDependencies({0x14000110f80?, 0x76?}, 0x1400011ead8?)
                /Users/brunoferreira/repos/terragrunt-atlantis-config/cmd/generate.go:125 +0x50
        github.com/transcend-io/terragrunt-atlantis-config/cmd.createProject({0x14000110f80, 0x76})
                /Users/brunoferreira/repos/terragrunt-atlantis-config/cmd/generate.go:328 +0xa4
        github.com/transcend-io/terragrunt-atlantis-config/cmd.main.func1()
                /Users/brunoferreira/repos/terragrunt-atlantis-config/cmd/generate.go:737 +0x78
        golang.org/x/sync/errgroup.(*Group).Go.func1()
                /Users/brunoferreira/go/pkg/mod/golang.org/x/sync@v0.4.0/errgroup/errgroup.go:75 +0x54
        created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 5
                /Users/brunoferreira/go/pkg/mod/golang.org/x/sync@v0.4.0/errgroup/errgroup.go:72 +0x98


goroutine 6 [running]:
golang.org/x/sync/singleflight.(*Group).doCall.func1()
        /Users/brunoferreira/go/pkg/mod/golang.org/x/sync@v0.4.0/singleflight/singleflight.go:170 +0x2cc
golang.org/x/sync/singleflight.(*Group).doCall(0x103219460?, 0x140000cf2c0?, {0x14000110f80?, 0x76?}, 0x103217000?)
        /Users/brunoferreira/go/pkg/mod/golang.org/x/sync@v0.4.0/singleflight/singleflight.go:205 +0x94
golang.org/x/sync/singleflight.(*Group).Do(0x103f28fc0, {0x14000110f80, 0x76}, 0x1400011ea38)
        /Users/brunoferreira/go/pkg/mod/golang.org/x/sync@v0.4.0/singleflight/singleflight.go:113 +0x1bc
github.com/transcend-io/terragrunt-atlantis-config/cmd.getDependencies({0x14000110f80?, 0x76?}, 0x1400011ead8?)
        /Users/brunoferreira/repos/terragrunt-atlantis-config/cmd/generate.go:125 +0x50
github.com/transcend-io/terragrunt-atlantis-config/cmd.createProject({0x14000110f80, 0x76})
        /Users/brunoferreira/repos/terragrunt-atlantis-config/cmd/generate.go:328 +0xa4
github.com/transcend-io/terragrunt-atlantis-config/cmd.main.func1()
        /Users/brunoferreira/repos/terragrunt-atlantis-config/cmd/generate.go:737 +0x78
golang.org/x/sync/errgroup.(*Group).Go.func1()
        /Users/brunoferreira/go/pkg/mod/golang.org/x/sync@v0.4.0/errgroup/errgroup.go:75 +0x54
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 5
        /Users/brunoferreira/go/pkg/mod/golang.org/x/sync@v0.4.0/errgroup/errgroup.go:72 +0x98

```

And now it's this:
```
Error: extra_atlantis_dependencies contains non-string value at position 4
```

This will allow faster troubleshooting for when there's a valid entry on the extra dependency array.
## Security Implications

- _[none]_

## System Availability

- _[none]_
