### PR TITLE
fixing issue with include external deps

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -527,8 +527,7 @@ func createHclProject(sourcePaths []string, workingDir string, projectHcl string
 			if err != nil {
 				return nil, err
 			}
-
-			if !strings.Contains(absolutePath, filepath.ToSlash(workingDir)) {
+			if strings.HasPrefix(relativePath, "..") {
 				relativeDependencies = append(relativeDependencies, filepath.ToSlash(relativePath))
 			}
 		}

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -181,7 +181,7 @@ func TestNonStringErrorOnExtraDeclaredDependencies(t *testing.T) {
 		filepath.Join("..", "test_examples_errors", "extra_dependency_error"),
 	})
 	err = rootCmd.Execute()
-	
+
 	expectedError := "extra_atlantis_dependencies contains non-string value at position 4"
 	if err == nil || err.Error() != expectedError {
 		t.Errorf("Expected error '%s', got '%v'", expectedError, err)
@@ -597,6 +597,17 @@ func TestRemoteModuleSourceTerraformRegistry(t *testing.T) {
 	runTest(t, filepath.Join("golden", "basic.yaml"), []string{
 		"--root",
 		filepath.Join("..", "test_examples", "remote_module_source_terraform_registry"),
+	})
+}
+
+func TestEnvHCLProjectsWithDeps(t *testing.T) {
+	runTest(t, filepath.Join("golden", "proj_hcl_with_external_deps.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "proj_hcl_with_external_deps", "my-stack"),
+		"--cascade-dependencies",
+		"--project-hcl-files=stack.hcl",
+		"--create-hcl-project-childs=false",
+		"--create-hcl-project-external-childs=false",
 	})
 }
 

--- a/cmd/golden/proj_hcl_with_external_deps.yaml
+++ b/cmd/golden/proj_hcl_with_external_deps.yaml
@@ -1,0 +1,14 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - '**/*.hcl'
+    - '**/*.tf*'
+    - ../_env/cluster/karpenter.hcl
+  dir: .
+version: 3

--- a/test_examples/proj_hcl_with_external_deps/_env/cluster/karpenter.hcl
+++ b/test_examples/proj_hcl_with_external_deps/_env/cluster/karpenter.hcl
@@ -1,0 +1,3 @@
+locals {
+  source_base_url = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}

--- a/test_examples/proj_hcl_with_external_deps/my-stack/nested/terragrunt.hcl
+++ b/test_examples/proj_hcl_with_external_deps/my-stack/nested/terragrunt.hcl
@@ -1,0 +1,15 @@
+
+include "stack" {
+  path = find_in_parent_folders("stack.hcl")
+}
+include "env" {
+  path   = "${get_terragrunt_dir()}/../../_env/cluster/karpenter.hcl"
+  expose = true
+}
+
+terraform {
+  source = include.env.locals.source_base_url
+}
+
+
+

--- a/test_examples/proj_hcl_with_external_deps/my-stack/stack.hcl
+++ b/test_examples/proj_hcl_with_external_deps/my-stack/stack.hcl
@@ -1,0 +1,3 @@
+locals {
+  environment = "qa"
+}


### PR DESCRIPTION
# Pull Request

## Description

This is to fix a bug where the code that build the hcl project doesn't correctly include external hcl files. There are cases where the abosulte path contains a "../", like in the test case I provided here. The old comparison would incorrectly assume that the hcl file is already included as the absolute path contains the working directory, even though the `../../` makes it so the directory is actually not in the working directory. This PR fixes this by just checking the relative path and seeing if it contains a `..`

