### PR TITLE
v1.21.1 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.21.0
+VERSION=1.21.1
 PATH_BUILD=build/
 FILE_COMMAND=terragrunt-atlantis-config
 FILE_ARCH=$(shell go env GOOS)_$(shell go env GOARCH)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.20.0
+VERSION=1.21.0
 PATH_BUILD=build/
 FILE_COMMAND=terragrunt-atlantis-config
 FILE_ARCH=$(shell go env GOOS)_$(shell go env GOARCH)

--- a/README.md
+++ b/README.md
@@ -217,9 +217,7 @@ Finally, check the log output (or your output file) for the YAML.
 
 To test any changes you've made, run `make gotestsum` (or `make test` for standard golang testing).
 
-When your PR is merged and a tag is created, a Github Actions job to build the new binary, test it, and deploy it's artifacts to Github Releases along with checksums.
-
-You can then open a PR on our homebrew tap similar to https://github.com/transcend-io/homebrew-tap/pull/4, and as soon as that merges your code will be released. Homebrew is not updated for every release, as Github is the primary artifact store.
+For maintainers, the directions on publishing a new release can be found [in the wiki](https://github.com/transcend-io/terragrunt-atlantis-config/wiki/How-to-publish-a-release).
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then, make sure `terragrunt-atlantis-config` is present on your Atlantis server.
 
 ```hcl
 variable "terragrunt_atlantis_config_version" {
-  default = "1.21.0"
+  default = "1.21.1"
 }
 
 build {
@@ -192,7 +192,7 @@ You can install this tool locally to checkout what kinds of config it will gener
 Recommended: Install any version via go install:
 
 ```bash
-go install github.com/transcend-io/terragrunt-atlantis-config@v1.21.0
+go install github.com/transcend-io/terragrunt-atlantis-config@v1.21.1
 ```
 
 This module officially supports golang version v1.23, tested on Github with each build. 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then, make sure `terragrunt-atlantis-config` is present on your Atlantis server.
 
 ```hcl
 variable "terragrunt_atlantis_config_version" {
-  default = "1.20.0"
+  default = "1.21.0"
 }
 
 build {
@@ -192,10 +192,10 @@ You can install this tool locally to checkout what kinds of config it will gener
 Recommended: Install any version via go install:
 
 ```bash
-go install github.com/transcend-io/terragrunt-atlantis-config@v1.17.9
+go install github.com/transcend-io/terragrunt-atlantis-config@v1.21.0
 ```
 
-This module officially supports golang version v1.21, tested on Github with each build. 
+This module officially supports golang version v1.23, tested on Github with each build. 
 This module also officially supports both Windows and Nix-based file formats, tested on Github with each build. 
 
 Usage Examples (see below sections for all options):

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import "github.com/transcend-io/terragrunt-atlantis-config/cmd"
 // This variable is set at build time using -ldflags parameters.
 // But we still set a default here for those using plain `go get` downloads
 // For more info, see: http://stackoverflow.com/a/11355611/483528
-var VERSION string = "1.21.0"
+var VERSION string = "1.21.1"
 
 func main() {
 	cmd.Execute(VERSION)

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import "github.com/transcend-io/terragrunt-atlantis-config/cmd"
 // This variable is set at build time using -ldflags parameters.
 // But we still set a default here for those using plain `go get` downloads
 // For more info, see: http://stackoverflow.com/a/11355611/483528
-var VERSION string = "1.20.0"
+var VERSION string = "1.21.0"
 
 func main() {
 	cmd.Execute(VERSION)


### PR DESCRIPTION
## Description

- Update version numbers for next release

## Security Implications

- Many different dependency updates resolving a variety of security issues

## Notes

I accidently published the v1.21.0 release too early, which is why I'm publishing v1.21.1. I updated the release steps so this mistake doesn't happen again.