### PR TITLE
fix: never resolve dependency outputs while generating config

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -150,13 +150,18 @@ func getDependencies(ctx *config.ParsingContext, path string) ([]string, error) 
 			}
 		}
 
-		// Parse the HCL file
+		// Parse the HCL file. Only decode dependency blocks when they are actually used:
+		// decoding them resolves each dependency's config (and, transitively, its own
+		// dependencies), which is expensive and can recurse for hours on deep chains.
+		decodeTypes := []config.PartialDecodeSectionType{
+			config.DependenciesBlock,
+			config.TerraformBlock,
+		}
+		if !ignoreDependencyBlocks {
+			decodeTypes = append(decodeTypes, config.DependencyBlock)
+		}
 		parseCtx := config.NewParsingContext(ctx, ctx.TerragruntOptions).
-			WithDecodeList(
-				config.DependencyBlock,
-				config.DependenciesBlock,
-				config.TerraformBlock,
-			)
+			WithDecodeList(decodeTypes...)
 		parsedConfig, err := config.PartialParseConfigFile(parseCtx, path, nil)
 		if err != nil {
 			getDependenciesCache.set(path, getDependenciesOutput{nil, err})
@@ -260,6 +265,7 @@ func getDependencies(ctx *config.ParsingContext, path string) ([]string, error) 
 
 			depPath := dep
 			terrOpts, _ := options.NewTerragruntOptionsWithConfigPath(depPath)
+			terrOpts.SkipOutput = true
 			terrOpts.OriginalTerragruntConfigPath = ctx.TerragruntOptions.OriginalTerragruntConfigPath
 			terrOpts.Env = ctx.TerragruntOptions.Env
 			terrContext := config.NewParsingContext(ctx, terrOpts)
@@ -325,6 +331,7 @@ func createProject(ctx context.Context, sourcePath string) (*AtlantisProject, er
 	if err != nil {
 		return nil, err
 	}
+	options.SkipOutput = true
 	options.OriginalTerragruntConfigPath = sourcePath
 	options.Env = getEnvs()
 
@@ -444,6 +451,7 @@ func createHclProject(ctx context.Context, sourcePaths []string, workingDir stri
 	if err != nil {
 		return nil, err
 	}
+	projectHclOptions.SkipOutput = true
 	projectHclOptions.Env = getEnvs()
 
 	parsingContext := config.NewParsingContext(ctx, projectHclOptions)
@@ -501,6 +509,7 @@ func createHclProject(ctx context.Context, sourcePaths []string, workingDir stri
 		if err != nil {
 			return nil, err
 		}
+		opt.SkipOutput = true
 		opt.Env = getEnvs()
 		parsingContext := config.NewParsingContext(ctx, opt)
 		dependencies, err := getDependencies(parsingContext, sourcePath)
@@ -581,6 +590,7 @@ func getAllTerragruntFiles(path string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	options.SkipOutput = true
 
 	// If filterPaths is provided, override workingPath instead of gitRoot
 	// We do this here because we want to keep the relative path structure of Terragrunt files

--- a/cmd/parse_locals.go
+++ b/cmd/parse_locals.go
@@ -98,6 +98,14 @@ func mergeResolvedLocals(parent ResolvedLocals, child ResolvedLocals) ResolvedLo
 
 // Parses a given file, returning a map of all it's `local` values
 func parseLocals(ctx *config.ParsingContext, path string, includeFromChild *config.IncludeConfig) (ResolvedLocals, error) {
+	// Use a non-empty partial-parse decode list that excludes DependencyBlock. With an
+	// empty decode list, terragrunt's parseIncludedConfig falls back to a FULL parse of
+	// any included config that contains a dependency block (see terragrunt
+	// config/include.go), which recursively resolves dependency outputs — on deep
+	// dependency chains this recursion can effectively never terminate. A partial parse
+	// still evaluates the included config's locals, which is all we need here.
+	ctx = ctx.WithDecodeList(config.DependenciesBlock, config.TerraformBlock)
+
 	file, err := hclparse.NewParser(ctx.ParserOptions...).ParseFromFile(path)
 	if err != nil {
 		return ResolvedLocals{}, err


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- Fixes #428
- Likely related: #419 (v1.21.1, generate never completing on a large monorepo — same parse layer)

## Description

Since the vendored terragrunt bump to 0.72.5 (#377, released in v1.21.1), `generate` resolves **real dependency outputs while parsing HCL**: each `dependency` block fetches the target stack's remote state and recursively re-parses the target's config and includes. Cost grows exponentially with dependency-chain depth — on a production monorepo, a single `generate --filter <one-dir>` against a stack whose included config carries 4–6 dependency blocks ran **17+ hours at full CPU without completing** (full diagnosis, goroutine dumps and root-cause walkthrough in #428).

`generate` is read-only and only ever needs dependency *paths* (for `when_modified` / `depends_on`); output *values* never appear in the generated config. Three small changes stop the resolution:

1. **Set `TerragruntOptions.SkipOutput = true`** at every options construction site in `cmd/generate.go`. Terragrunt's own gate (`shouldGetOutputs`, `config/dependency.go`) then skips output fetching and degrades gracefully to mock outputs.
2. **`parseLocals`: use a non-empty partial-parse decode list (without `DependencyBlock`).** With an empty decode list, terragrunt's `parseIncludedConfig` falls back to a FULL parse of any included config that contains a dependency block — the entry point into recursive output resolution. A partial parse still evaluates the included config's locals, which is all `parseLocals` needs.
3. **`getDependencies`: only decode `DependencyBlock` when `--ignore-dependency-blocks` is not set.** Previously the expensive decode always ran and its result was discarded when the flag was set.

## Validation

- Against the affected production monorepo: stacks whose generation previously never terminated complete in **<1s**, emitting identical project entries (dir, workspace, `extra_atlantis_dependencies`).
- `go test ./cmd/`: passes, identical to the unpatched v1.21.1 baseline — including the dependency-discovery golden tests (`TestTerragruntDependencies`, `TestChainedDependencies`, `TestWithDependsOn`), so dependency-path discovery for users *not* passing `--ignore-dependency-blocks` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)